### PR TITLE
docs: correct GPIO memory addresses in MCU selection document

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -450,7 +450,7 @@ classDiagram
 ```mermaid
 graph LR
     subgraph "Platform layer"
-        GPIOA_MODER["Register&lt;0x42020000&gt;"]
+        GPIOA_MODER["Register&lt;0x50000000&gt;"]
         MODER_PIN5["BitField&lt;GPIOA_MODER, 10, 2, RW, PinMode&gt;"]
     end
     subgraph "Peripheral layer"

--- a/docs/steps/step-06-mcu-selection.md
+++ b/docs/steps/step-06-mcu-selection.md
@@ -26,7 +26,7 @@ and a skeleton for the first platform (STM32U0 / STM32U083).
   - `LCKR` offset `0x1C` — configuration lock register
   - `AFRL` offset `0x20` — alternate function low (pins 0–7)
   - `AFRH` offset `0x24` — alternate function high (pins 8–15)
-  - `BRR` offset `0x28` - bit reset register (WO)
+  - `BRR` offset `0x28` — bit reset register (WO)
 
 ## `platform.hpp` Logic
 

--- a/docs/steps/step-06-mcu-selection.md
+++ b/docs/steps/step-06-mcu-selection.md
@@ -8,13 +8,13 @@ and a skeleton for the first platform (STM32U0 / STM32U083).
 - MCU family: STM32U0
 - MCU model: STM32U083
 - Peripheral: GPIO
-- Register base addresses (STM32U083 Reference Manual RM0503):
-  - GPIOA base: `0x42020000`
-  - GPIOB base: `0x42020400`
-  - GPIOC base: `0x42020800`
-  - GPIOD base: `0x42020C00`
-  - GPIOE base: `0x42021000`
-  - GPIOF base: `0x42021400`
+- Register base addresses (STM32U083 Reference Manual RM0503 Rev 4 - Table 4):
+  - GPIOA base: `0x50000000`
+  - GPIOB base: `0x50000400`
+  - GPIOC base: `0x50000800`
+  - GPIOD base: `0x50000C00`
+  - GPIOE base: `0x50001000`
+  - GPIOF base: `0x50001400`
 - Register offsets within each GPIO block (identical across all STM32U0 GPIO ports):
   - `MODER` offset `0x00` — pin mode (Input / Output / AF / Analog)
   - `OTYPER` offset `0x04` — output type (Push-Pull / Open-Drain)
@@ -26,6 +26,7 @@ and a skeleton for the first platform (STM32U0 / STM32U083).
   - `LCKR` offset `0x1C` — configuration lock register
   - `AFRL` offset `0x20` — alternate function low (pins 0–7)
   - `AFRH` offset `0x24` — alternate function high (pins 8–15)
+  - `BRR` offset `0x28` - bit reset register (WO)
 
 ## `platform.hpp` Logic
 

--- a/docs/steps/step-08-stm32u0-gpio.md
+++ b/docs/steps/step-08-stm32u0-gpio.md
@@ -47,28 +47,28 @@ struct Pin<PortA, PinNum> {
     static_assert(PinNum < 16u, "ohal: STM32U083 GPIOA has pins 0-15 only.");
 
     using MODER  = core::BitField<
-        core::Register<0x42020000u>, PinNum * 2u, 2u,
+        core::Register<0x50000000u>, PinNum * 2u, 2u,
         core::Access::ReadWrite, PinMode>;
     using OTYPER = core::BitField<
-        core::Register<0x42020004u>, PinNum, 1u,
+        core::Register<0x50000004u>, PinNum, 1u,
         core::Access::ReadWrite, OutputType>;
     using OSPEEDR = core::BitField<
-        core::Register<0x42020008u>, PinNum * 2u, 2u,
+        core::Register<0x50000008u>, PinNum * 2u, 2u,
         core::Access::ReadWrite, Speed>;
     using PUPDR  = core::BitField<
-        core::Register<0x4202000Cu>, PinNum * 2u, 2u,
+        core::Register<0x5000000Cu>, PinNum * 2u, 2u,
         core::Access::ReadWrite, Pull>;
     using IDR    = core::BitField<
-        core::Register<0x42020010u>, PinNum, 1u,
+        core::Register<0x50000010u>, PinNum, 1u,
         core::Access::ReadOnly, Level>;
     using ODR    = core::BitField<
-        core::Register<0x42020014u>, PinNum, 1u,
+        core::Register<0x50000014u>, PinNum, 1u,
         core::Access::ReadWrite, Level>;
     // BSRR: bits 0-15 = set high, bits 16-31 = set low; modelled as two write-only fields
     using BSRR_SET   = core::BitField<
-        core::Register<0x42020018u>, PinNum,       1u, core::Access::WriteOnly>;
+        core::Register<0x50000018u>, PinNum,       1u, core::Access::WriteOnly>;
     using BSRR_RESET = core::BitField<
-        core::Register<0x42020018u>, PinNum + 16u, 1u, core::Access::WriteOnly>;
+        core::Register<0x50000018u>, PinNum + 16u, 1u, core::Access::WriteOnly>;
 
     static void set_mode(PinMode mode) noexcept        { MODER::write(mode); }
     static void set_output_type(OutputType t) noexcept { OTYPER::write(t); }
@@ -85,8 +85,8 @@ struct Pin<PortA, PinNum> {
 };
 
 // Repeat for PortB ... PortF (identical structure, different base address)
-// PortB base: 0x42020400, PortC: 0x42020800, PortD: 0x42020C00,
-// PortE: 0x42021000, PortF: 0x42021400
+// PortB base: 0x50000400, PortC: 0x50000800, PortD: 0x50000C00,
+// PortE: 0x50001000, PortF: 0x50001400
 
 } // namespace ohal::gpio
 


### PR DESCRIPTION
Updated GPIO register base addresses for STM32U083 to reflect changes in the reference manual.

<!--
PR title MUST follow Conventional Commits format:

  <type>(<scope>): <short summary>

  type  : feat | fix | docs | test | ci | build | refactor | chore
  scope : optional — e.g. core | gpio | stm32u0 | pic | ci | vcpkg
  summary: present tense, lowercase, no trailing period

Examples:
  feat(gpio): add STM32U073 partial specialisation
  fix(core): correct mask calculation for Width=1 BitField at Offset=31
  docs(plan): add step-16 additional peripherals
  ci: add nRF5 cross-compile job

The PR title becomes the squash-merge commit message and is read by
release-please to determine version bumps and CHANGELOG entries.
-->
