### PR TITLE
docs: added structured spec for stm32u0 family

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y clang-format clang-tidy cmake shellcheck
-          pip3 install cmakelang yamllint
+          pip3 install cmakelang yamllint check-jsonschema
           npm install -g markdownlint-cli2 prettier
 
       - name: Run lint.sh

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,25 +1,31 @@
 # Device-Family Register Specifications
 
-This directory contains structured YAML specifications for STM32 device families. Each spec captures
-memory-map and peripheral register/field metadata directly from the vendor reference manual.
+This directory contains structured YAML specifications for microcontroller device families from any
+vendor. Each spec captures memory-map and peripheral register/field metadata directly from the
+vendor reference manual.
 
 ## Directory Layout
 
 ```text
 docs/specs/
-├── README.md           ← this file
-└── stm32/
-    ├── schema.json     ← JSON Schema for all STM32 spec files
-    └── stm32u0.yml     ← STM32U0 family specification
+├── README.md                  ← this file
+├── schema.json                ← common JSON Schema for all spec files
+├── future_improvements.md     ← options for cross-family/cross-vendor settings sharing
+└── {vendor}/                  ← one subdirectory per vendor (e.g. stm32, nxp, nordic)
+    └── {family}.yml           ← one spec file per device family
 ```
+
+**Vendor directory naming:** use the vendor's product-line prefix in lowercase (e.g. `stm32` for
+STMicroelectronics STM32, `nrf` for Nordic nRF, `lpc` for NXP LPC).
 
 ## Format Overview
 
-Every spec file is a YAML document validated against `docs/specs/stm32/schema.json`. The top-level
-keys are:
+Every spec file is a YAML document validated against `docs/specs/schema.json`. The top-level keys
+are:
 
 | Key            | Required | Description                                                       |
 | -------------- | -------- | ----------------------------------------------------------------- |
+| `vendor`       | ✓        | Chip vendor name (e.g. 'STMicroelectronics')                      |
 | `family`       | ✓        | Family name and sub-family list                                   |
 | `architecture` | ✓        | Processor architecture and word size                              |
 | `reference`    | ✓        | Reference manual document identifier and revision                 |
@@ -28,6 +34,15 @@ keys are:
 | `peripherals`  |          | Peripheral blocks with register and bit-field descriptions        |
 
 ## Key Concepts
+
+### Vendor
+
+Every spec must declare the chip vendor so that the spec is self-describing independently of its
+directory location:
+
+```yaml
+vendor: STMicroelectronics
+```
 
 ### Sub-family applicability
 
@@ -180,12 +195,12 @@ under `sequence`:
 
 ## Validation
 
-Specs are validated against `docs/specs/stm32/schema.json` as part of CI (see `lint.sh` and the
-`lint.yml` workflow).
+Specs are validated against `docs/specs/schema.json` as part of CI (see `lint.sh` and the `lint.yml`
+workflow).
 
 To validate locally:
 
 ```sh
 pip install check-jsonschema
-check-jsonschema --schemafile docs/specs/stm32/schema.json docs/specs/stm32/stm32u0.yml
+check-jsonschema --schemafile docs/specs/schema.json docs/specs/stm32/stm32u0.yml
 ```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,8 +9,11 @@ vendor reference manual.
 ```text
 docs/specs/
 ├── README.md                  ← this file
-├── schema.json                ← common JSON Schema for all spec files
+├── schema.json                ← common JSON Schema for family spec files
 ├── future_improvements.md     ← options for cross-family/cross-vendor settings sharing
+├── common/
+│   └── arch/
+│       └── {arch}.yml         ← one architecture-level spec per processor architecture
 └── {vendor}/                  ← one subdirectory per vendor (e.g. stm32, nxp, nordic)
     └── {family}.yml           ← one spec file per device family
 ```
@@ -28,7 +31,8 @@ are:
 | `spec-version` | ✓        | Spec format version using semver (e.g. `"1.0.0"`)                 |
 | `vendor`       | ✓        | Chip vendor name (e.g. 'STMicroelectronics')                      |
 | `family`       | ✓        | Family name and sub-family list                                   |
-| `architecture` | ✓        | Processor architecture and word size                              |
+| `architecture` | ✓        | Processor architecture and word size (inline summary)             |
+| `arch-ref`     |          | Reference to an architecture-level spec (see below)               |
 | `reference`    | ✓        | Reference manual document identifier and revision                 |
 | `memory`       |          | Memory map with address ranges and sub-family applicability       |
 | `definitions`  |          | Reusable settings blocks (referenced by YAML anchors in the spec) |
@@ -57,6 +61,28 @@ directory location:
 ```yaml
 vendor: STMicroelectronics
 ```
+
+### Architecture reference
+
+Family specs that belong to a well-known processor architecture can declare an `arch-ref` key
+pointing to an architecture-level spec file in `docs/specs/common/arch/`:
+
+```yaml
+arch-ref: cortex-m0plus
+```
+
+The corresponding file (`docs/specs/common/arch/cortex-m0plus.yml`) is the canonical source of
+truth for:
+
+- Architecture metadata: word size, endianness, ISA name
+- Private Peripheral Bus (PPB) memory regions (e.g. NVIC, SysTick, SCB address ranges)
+- Settings encodings that are identical on every device implementing this architecture (e.g.
+  the standard ARM Cortex-M GPIO mode encoding `gpio-mode`)
+
+Because YAML anchors cannot span files, architecture-generic settings that are used as YAML
+aliases within a family spec (e.g. `*gpio-mode`) must also be defined in `definitions.settings` of
+that family spec. Those local copies are annotated with a comment noting that the canonical
+definition lives in the architecture spec.
 
 ### Sub-family applicability
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -186,25 +186,56 @@ peripherals:
 ### Register access sequences
 
 Some registers require a specific access sequence (e.g. the GPIO lock register). Document these
-under `sequence`:
+under `sequence`, which is an object with a required `description` and an ordered `steps` list:
 
 ```yaml
 - LCKR:
     sequence:
-      - write:
-          - LCKK: 1
-            LCKR: bits 15:0
-      - write:
-          - LCKK: 0
-            LCKR: bits 15:0
-      - write:
-          - LCKK: 1
-            LCKR: bits 15:0
-      - read:
-          - LCKR: bits 31:0
+      description: >-
+        Lock sequence that must be followed exactly to freeze the port configuration.
+        Accepts one caller argument: lock-bits, a 16-bit mask (LCK0–LCK15) indicating
+        which port pins to lock.
+      steps:
+        - op: write
+          note: Write LCKK=1 with the desired lock-bits
+          fields:
+            LCKK: 1
+            LCK: write-arg
+        - op: write
+          note: Write LCKK=0 with the same lock-bits
+          fields:
+            LCKK: 0
+            LCK: write-arg
+        - op: write
+          note: Write LCKK=1 with the same lock-bits again
+          fields:
+            LCKK: 1
+            LCK: write-arg
+        - op: read
+          note: Read the register to complete the lock sequence (result discarded)
+        - op: read
+          optional: true
+          note: Optional — LCKK reads back as 1 when the lock is active
+          expect:
+            LCKK: 1
     fields:
       # ...
 ```
+
+#### Step fields
+
+Each step has a required `op` key (`read` or `write`) and the following optional keys:
+
+| Key        | Applies to | Description                                                                                                                                     |
+| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `note`     | any        | Human-readable explanation of the step, including timing or ordering constraints                                                                |
+| `optional` | any        | If `true` the step may be omitted. Defaults to `false`                                                                                          |
+| `fields`   | `write`    | Field-name → value mapping. Values are non-negative integers (bit pattern for that field, within its bit width) or `"write-arg"` (caller value) |
+| `expect`   | `read`     | Field-name → expected-value mapping. Consumers should treat a mismatch as a sequence failure. Omit on read steps where the result is discarded  |
+
+`write-arg` indicates that the caller supplies the value for that field. The sequence `description`
+must document what each `write-arg` represents so that consumers can implement the sequence
+correctly. `fields` must not appear on `read` steps; `expect` must not appear on `write` steps.
 
 ## Validation
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -25,7 +25,7 @@ are:
 
 | Key            | Required | Description                                                       |
 | -------------- | -------- | ----------------------------------------------------------------- |
-| `spec-version` | ✓        | Spec format version (e.g. `"1.0"`)                                |
+| `spec-version` | ✓        | Spec format version using semver (e.g. `"1.0.0"`)                 |
 | `vendor`       | ✓        | Chip vendor name (e.g. 'STMicroelectronics')                      |
 | `family`       | ✓        | Family name and sub-family list                                   |
 | `architecture` | ✓        | Processor architecture and word size                              |
@@ -41,12 +41,13 @@ are:
 Every spec must declare the format version as the first key:
 
 ```yaml
-spec-version: "1.0"
+spec-version: "1.0.0"
 ```
 
-The version uses `MAJOR.MINOR` semantics: increment the minor version for backward-compatible
-additions, the major version for breaking changes. Tooling can use this field to warn about or
-reject stale spec files.
+The version uses [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`): increment the
+patch version for corrections, the minor version for backward-compatible additions, and the major
+version for breaking changes. Pre-release and build-metadata suffixes (e.g. `1.0.0-alpha.1`) are
+also permitted. Tooling can use this field to warn about or reject stale spec files.
 
 ### Vendor
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,6 +11,7 @@ docs/specs/
 ├── README.md                  ← this file
 ├── schema.json                ← JSON Schema for family spec files
 ├── schema-model.json          ← JSON Schema for device-model spec files
+├── schema-arch.json           ← JSON Schema for architecture spec files
 ├── future_improvements.md     ← options for cross-family/cross-vendor settings sharing
 ├── common/
 │   └── arch/
@@ -24,10 +25,24 @@ docs/specs/
 **Vendor directory naming:** use the vendor's product-line prefix in lowercase (e.g. `stm32` for
 STMicroelectronics STM32, `nrf` for Nordic nRF, `lpc` for NXP LPC).
 
+## Spec Types and Schemas
+
+There are three distinct spec file types, each with its own JSON Schema:
+
+| Spec type    | Location                                | Schema              | Description                                                |
+| ------------ | --------------------------------------- | ------------------- | ---------------------------------------------------------- |
+| Architecture | `docs/specs/common/arch/{arch}.yml`     | `schema-arch.json`  | Architecture-level metadata shared by all devices of that  |
+|              |                                         |                     | architecture (word size, endianness, PPB regions, common   |
+|              |                                         |                     | settings encodings)                                        |
+| Family       | `docs/specs/{vendor}/{family}.yml`      | `schema.json`       | Device-family register map and peripheral metadata         |
+| Model        | `docs/specs/{vendor}/models/{part}.yml` | `schema-model.json` | Per-part-number details (package, flash/SRAM sizes, pin AF |
+|              |                                         |                     | table, errata)                                             |
+
 ## Format Overview
 
-Every spec file is a YAML document validated against `docs/specs/schema.json`. The top-level keys
-are:
+### Family spec top-level keys
+
+Family specs (`docs/specs/{vendor}/{family}.yml`) are validated against `schema.json`:
 
 | Key            | Required | Description                                                       |
 | -------------- | -------- | ----------------------------------------------------------------- |
@@ -40,6 +55,22 @@ are:
 | `memory`       |          | Memory map with address ranges and sub-family applicability       |
 | `definitions`  |          | Reusable settings blocks (referenced by YAML anchors in the spec) |
 | `peripherals`  |          | Peripheral blocks with register and bit-field descriptions        |
+
+### Architecture spec top-level keys
+
+Architecture specs (`docs/specs/common/arch/{arch}.yml`) are validated against `schema-arch.json`:
+
+| Key            | Required | Description                                                               |
+| -------------- | -------- | ------------------------------------------------------------------------- |
+| `spec-version` | ✓        | Spec format version using semver (e.g. `"1.0.0"`)                         |
+| `architecture` | ✓        | Architecture name, word size, and endianness                              |
+| `memory`       |          | Architecture-defined memory regions (e.g. PPB) common to all devices      |
+| `definitions`  |          | Architecturally-defined settings encodings (e.g. standard GPIO mode bits) |
+
+### Model spec top-level keys
+
+Device-model specs (`docs/specs/{vendor}/models/{part}.yml`) are validated against
+`schema-model.json`. See the `schema-model.json` file for the full key reference.
 
 ## Key Concepts
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,191 @@
+# Device-Family Register Specifications
+
+This directory contains structured YAML specifications for STM32 device families. Each spec captures
+memory-map and peripheral register/field metadata directly from the vendor reference manual.
+
+## Directory Layout
+
+```text
+docs/specs/
+├── README.md           ← this file
+└── stm32/
+    ├── schema.json     ← JSON Schema for all STM32 spec files
+    └── stm32u0.yml     ← STM32U0 family specification
+```
+
+## Format Overview
+
+Every spec file is a YAML document validated against `docs/specs/stm32/schema.json`. The top-level
+keys are:
+
+| Key            | Required | Description                                                       |
+| -------------- | -------- | ----------------------------------------------------------------- |
+| `family`       | ✓        | Family name and sub-family list                                   |
+| `architecture` | ✓        | Processor architecture and word size                              |
+| `reference`    | ✓        | Reference manual document identifier and revision                 |
+| `memory`       |          | Memory map with address ranges and sub-family applicability       |
+| `definitions`  |          | Reusable settings blocks (referenced by YAML anchors in the spec) |
+| `peripherals`  |          | Peripheral blocks with register and bit-field descriptions        |
+
+## Key Concepts
+
+### Sub-family applicability
+
+Many registers and memory regions differ between sub-families (e.g. flash size). The `sub-families`
+key on a memory region or register lists which sub-families the entry applies to.
+
+### References
+
+`reference` blocks provide back-links to the vendor reference manual:
+
+```yaml
+reference:
+  sections: [7.4, 7.4.1] # for peripherals (list of sections)
+  section: 7.4.1 # for individual registers (single section)
+  figures: [2]
+  tables: [41]
+```
+
+### Memory map
+
+Each entry in `memory.map` is a named address range:
+
+```yaml
+memory:
+  map:
+    - name: Main flash memory
+      sub-families: [stm32u031]
+      start: 0x08000000
+      end: 0x0801FFFF
+    - name: reserved
+      sub-families: [stm32u031]
+      start: 0x08020000
+      end: 0x1FFFD7FF
+```
+
+### Peripherals
+
+Peripherals are listed under `peripherals`. Each item is a single-key mapping whose key is the
+peripheral name and whose value contains `registers`:
+
+```yaml
+peripherals:
+  - gpio:
+      reference:
+        sections: [7.4]
+      registers:
+        - MODER:
+            reference:
+              section: 7.4.1
+            offset: 0x00
+            fields:
+              - name: MODE15
+                msb: 31
+                lsb: 30
+                width: 2
+                access: rw
+                settings: *gpio-mode
+```
+
+### Register fields
+
+Each field has:
+
+| Key        | Type                 | Description                                         |
+| ---------- | -------------------- | --------------------------------------------------- |
+| `name`     | string               | Field name from the reference manual                |
+| `msb`      | integer              | Most-significant bit position (inclusive, 0-based)  |
+| `lsb`      | integer              | Least-significant bit position (inclusive, 0-based) |
+| `width`    | integer              | Field width in bits (must equal `msb - lsb + 1`)    |
+| `access`   | `rw` \| `ro` \| `wo` | Read/write, read-only, or write-only                |
+| `note`     | string (optional)    | Free-text annotation                                |
+| `settings` | mapping or `~`       | Enumerated bit-pattern values (see below)           |
+
+The `access` values are:
+
+- `rw` — read/write
+- `ro` — read-only
+- `wo` — write-only (hardware ignores the read value)
+
+### Settings
+
+`settings` is a mapping from binary bit-pattern strings to human-readable descriptions:
+
+```yaml
+settings:
+  "00": input mode
+  "01": general purpose output mode
+  "10": alternate function mode
+  "11": analogue mode
+```
+
+Use `settings: ~` (null) for reserved fields that have no documented settings.
+
+Keys **must** be quoted strings (e.g. `"00"`, `"10"`) even though they look numeric, to prevent YAML
+1.1 parsers from converting them to integers.
+
+### Reducing duplication with YAML anchors
+
+When the same settings block repeats across many fields (e.g. all 16 bits in a GPIO mode register
+share identical encoding), define the block once under `definitions` using a YAML anchor and
+reference it elsewhere with a YAML alias:
+
+```yaml
+definitions:
+  settings:
+    gpio-mode: &gpio-mode # anchor definition
+      "00": input mode
+      "01": general purpose output mode
+      "10": alternate function mode
+      "11": analogue mode
+
+peripherals:
+  - gpio:
+      registers:
+        - MODER:
+            fields:
+              - name: MODE15
+                msb: 31
+                lsb: 30
+                width: 2
+                access: rw
+                settings: *gpio-mode # alias reference
+              - name: MODE14
+                # ...
+                settings: *gpio-mode
+```
+
+### Register access sequences
+
+Some registers require a specific access sequence (e.g. the GPIO lock register). Document these
+under `sequence`:
+
+```yaml
+- LCKR:
+    sequence:
+      - write:
+          - LCKK: 1
+            LCKR: bits 15:0
+      - write:
+          - LCKK: 0
+            LCKR: bits 15:0
+      - write:
+          - LCKK: 1
+            LCKR: bits 15:0
+      - read:
+          - LCKR: bits 31:0
+    fields:
+      # ...
+```
+
+## Validation
+
+Specs are validated against `docs/specs/stm32/schema.json` as part of CI (see `lint.sh` and the
+`lint.yml` workflow).
+
+To validate locally:
+
+```sh
+pip install check-jsonschema
+check-jsonschema --schemafile docs/specs/stm32/schema.json docs/specs/stm32/stm32u0.yml
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -25,6 +25,7 @@ are:
 
 | Key            | Required | Description                                                       |
 | -------------- | -------- | ----------------------------------------------------------------- |
+| `spec-version` | ✓        | Spec format version (e.g. `"1.0"`)                                |
 | `vendor`       | ✓        | Chip vendor name (e.g. 'STMicroelectronics')                      |
 | `family`       | ✓        | Family name and sub-family list                                   |
 | `architecture` | ✓        | Processor architecture and word size                              |
@@ -34,6 +35,18 @@ are:
 | `peripherals`  |          | Peripheral blocks with register and bit-field descriptions        |
 
 ## Key Concepts
+
+### Spec version
+
+Every spec must declare the format version as the first key:
+
+```yaml
+spec-version: "1.0"
+```
+
+The version uses `MAJOR.MINOR` semantics: increment the minor version for backward-compatible
+additions, the major version for breaking changes. Tooling can use this field to warn about or
+reject stale spec files.
 
 ### Vendor
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -121,6 +121,15 @@ memory:
       end: 0x1FFFD7FF
 ```
 
+Optional per-entry keys:
+
+| Key            | Description                                                                                                                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sub-families` | Sub-family identifiers for which this region exists. Omit if the region is present in all sub-families.                                                                                       |
+| `base`         | Peripheral base address for register offset calculations, when it differs from the region's `start` address. Consumers must use this address (not `start`) when computing register addresses. |
+| `verified`     | Set to `false` to flag a region that is provisional or still needs checking against the reference manual. Defaults to `true` (verified).                                                      |
+| `note`         | Free-text annotation for cases not covered by the structured keys above.                                                                                                                      |
+
 ### Peripherals
 
 Peripherals are listed under `peripherals`. Each item is a single-key mapping whose key is the
@@ -159,21 +168,42 @@ present in all sub-families.
 
 Each field has:
 
-| Key        | Type                 | Description                                         |
-| ---------- | -------------------- | --------------------------------------------------- |
-| `name`     | string               | Field name from the reference manual                |
-| `msb`      | integer              | Most-significant bit position (inclusive, 0-based)  |
-| `lsb`      | integer              | Least-significant bit position (inclusive, 0-based) |
-| `width`    | integer              | Field width in bits (must equal `msb - lsb + 1`)    |
-| `access`   | `rw` \| `ro` \| `wo` | Read/write, read-only, or write-only                |
-| `note`     | string (optional)    | Free-text annotation                                |
-| `settings` | mapping or `~`       | Enumerated bit-pattern values (see below)           |
+| Key             | Type                 | Description                                                                                        |
+| --------------- | -------------------- | -------------------------------------------------------------------------------------------------- |
+| `name`          | string               | Field name from the reference manual                                                               |
+| `msb`           | integer              | Most-significant bit position (inclusive, 0-based)                                                 |
+| `lsb`           | integer              | Least-significant bit position (inclusive, 0-based)                                                |
+| `width`         | integer              | Field width in bits (must equal `msb - lsb + 1`)                                                   |
+| `access`        | `rw` \| `ro` \| `wo` | Read/write, read-only, or write-only                                                               |
+| `note`          | string (optional)    | Free-text annotation for cases not covered by the structured keys                                  |
+| `priority-over` | list (optional)      | Names of fields in the same register that this field overrides in a simultaneous write (see below) |
+| `settings`      | mapping or `~`       | Enumerated bit-pattern values (see below)                                                          |
 
 The `access` values are:
 
 - `rw` — read/write
 - `ro` — read-only
 - `wo` — write-only (hardware ignores the read value)
+
+### Field write-conflict priority
+
+Some registers contain pairs of fields that represent conflicting operations on the same bit (e.g.
+BSRR's BSx / BRx set/reset pairs). When both fields are written with a non-zero value in the same
+register write, the hardware applies only one of them. Document this with `priority-over`:
+
+```yaml
+- name: BS0
+  msb: 0
+  lsb: 0
+  width: 1
+  access: wo
+  priority-over: [BR0]  # if both BS0=1 and BR0=1 are written, BS0's effect wins
+  settings: *bsrr-bs
+```
+
+`priority-over` is a list of field names in the **same register** that this field's effect overrides
+when both are written simultaneously. The listed fields' writes are silently discarded by the
+hardware. Consumers implementing a write to such a register should warn or document this behaviour.
 
 ### Settings
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,13 +9,16 @@ vendor reference manual.
 ```text
 docs/specs/
 ├── README.md                  ← this file
-├── schema.json                ← common JSON Schema for family spec files
+├── schema.json                ← JSON Schema for family spec files
+├── schema-model.json          ← JSON Schema for device-model spec files
 ├── future_improvements.md     ← options for cross-family/cross-vendor settings sharing
 ├── common/
 │   └── arch/
 │       └── {arch}.yml         ← one architecture-level spec per processor architecture
 └── {vendor}/                  ← one subdirectory per vendor (e.g. stm32, nxp, nordic)
-    └── {family}.yml           ← one spec file per device family
+    ├── {family}.yml           ← one family spec per device family
+    └── models/
+        └── {part-number}.yml  ← one device-model spec per part number
 ```
 
 **Vendor directory naming:** use the vendor's product-line prefix in lowercase (e.g. `stm32` for
@@ -121,13 +124,18 @@ memory:
 ### Peripherals
 
 Peripherals are listed under `peripherals`. Each item is a single-key mapping whose key is the
-peripheral name and whose value contains `registers`:
+peripheral name and whose value contains an optional `instances` list and `registers`:
 
 ```yaml
 peripherals:
   - gpio:
       reference:
         sections: [7.4]
+      instances:
+        - name: GPIOA
+          base: 0x50000000
+        - name: GPIOB
+          base: 0x50000400
       registers:
         - MODER:
             reference:
@@ -141,6 +149,11 @@ peripherals:
                 access: rw
                 settings: *gpio-mode
 ```
+
+The `instances` list binds the generic register layout to the concrete base addresses in the memory
+map. Each instance has a required `name` and `base`, and an optional `sub-families` list (for
+peripherals whose availability varies across sub-families). Omit `sub-families` if the instance is
+present in all sub-families.
 
 ### Register fields
 
@@ -264,14 +277,57 @@ Each step has a required `op` key (`read` or `write`) and the following optional
 must document what each `write-arg` represents so that consumers can implement the sequence
 correctly. `fields` must not appear on `read` steps; `expect` must not appear on `write` steps.
 
+## Device-model specs
+
+A device-model spec (in `{vendor}/models/{part-number}.yml`) describes a specific part number,
+package, and silicon revision. It is validated against `docs/specs/schema-model.json`.
+
+The required top-level keys are:
+
+| Key            | Type    | Description                                 |
+| -------------- | ------- | ------------------------------------------- |
+| `spec-version` | string  | Spec format version (semver)                |
+| `vendor`       | string  | Must match the parent family spec           |
+| `family-ref`   | string  | Family spec identifier (e.g. `stm32u0`)     |
+| `model`        | string  | Part number identifier (e.g. `stm32u031c4`) |
+| `package`      | string  | Package code (e.g. `UFQFPN32`, `LQFP48`)    |
+| `flash-kb`     | integer | On-chip flash in kibibytes                  |
+| `sram-kb`      | integer | On-chip SRAM in kibibytes                   |
+| `pin-count`    | integer | Number of physical pins                     |
+
+Optional keys:
+
+| Key                       | Description                                                 |
+| ------------------------- | ----------------------------------------------------------- |
+| `peripheral-availability` | Which peripheral instances from the family spec are present |
+| `alternate-functions`     | Per-pin AF mapping table (AF0-AF15 -> signal names)         |
+| `errata`                  | Known hardware errata with silicon-revision applicability   |
+
+Example:
+
+```yaml
+spec-version: "1.0.0"
+vendor: STMicroelectronics
+family-ref: stm32u0
+model: stm32u031c4
+package: UFQFPN32
+flash-kb: 256
+sram-kb: 12
+pin-count: 32
+peripheral-availability:
+  - peripheral: gpio
+    instances: [GPIOA, GPIOB, GPIOC, GPIOD, GPIOF]
+```
+
 ## Validation
 
-Specs are validated against `docs/specs/schema.json` as part of CI (see `lint.sh` and the `lint.yml`
-workflow).
+Family specs are validated against `docs/specs/schema.json` and model specs against
+`docs/specs/schema-model.json` as part of CI (see `lint.sh` and the `lint.yml` workflow).
 
 To validate locally:
 
 ```sh
 pip install check-jsonschema
 check-jsonschema --schemafile docs/specs/schema.json docs/specs/stm32/stm32u0.yml
+check-jsonschema --schemafile docs/specs/schema-model.json docs/specs/stm32/models/stm32u031c4.yml
 ```

--- a/docs/specs/common/arch/cortex-m0plus.yml
+++ b/docs/specs/common/arch/cortex-m0plus.yml
@@ -1,0 +1,26 @@
+---
+spec-version: "1.0.0"
+architecture:
+  name: ARM Cortex-M0+
+  word-size: 32
+  endianness: little
+memory:
+  note: >-
+    Private Peripheral Bus (PPB) address regions defined by the ARM Cortex-M0+ architecture. These
+    regions are identical on every Cortex-M0+ implementation regardless of vendor or device family.
+  map:
+    - name: Cortex-M0+ internal peripherals
+      start: 0xE0000000
+      end: 0xE00FFFFF
+definitions:
+  settings:
+    # Standard GPIO mode encoding shared by all ARM Cortex-M GPIO controllers.
+    gpio-mode:
+      "00": input mode
+      "01": general purpose output mode
+      "10": alternate function mode
+      "11": analogue mode
+    # Universal single-bit encoding for any field that simply sets or clears a signal.
+    bit-value:
+      "0": reset
+      "1": set

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -1,0 +1,171 @@
+# Future Improvements: Cross-Family and Cross-Vendor Settings Sharing
+
+The current spec format stores all `definitions.settings` blocks inside individual spec files. This
+works well for a single family but leads to duplication when the same settings encoding appears
+across multiple families or vendors. This document describes the problem and evaluates options for
+addressing it.
+
+## Problem
+
+Many peripheral settings encodings are identical across device families and even across vendors,
+because they implement the same IP (e.g. ARM Cortex-M GPIO) or follow the same de-facto convention:
+
+| Settings block | Families sharing it                                            |
+| -------------- | -------------------------------------------------------------- |
+| `gpio-mode`    | All ARM Cortex-M devices with standard GPIO (STM32, NXP, etc.) |
+| `output-type`  | STM32Lx, STM32Ux, STM32Hx, and others                          |
+| `ospeed`       | STM32Lx, STM32Ux, STM32Hx, and others                          |
+| `pupdr`        | Most ARM Cortex-M GPIO implementations                         |
+| `bit-value`    | Universal (any single-bit field that is simply set or reset)   |
+
+When the same settings block is copy-pasted into every spec file, a typo or update must be applied
+to every copy. A shared definitions mechanism would provide a single source of truth.
+
+## Constraints
+
+The spec format is plain YAML. YAML 1.2 (and YAML 1.1) have no built-in cross-file `include` or
+`$ref`. Any cross-file sharing therefore requires either tooling support or a change in the
+validation strategy.
+
+## Options
+
+### Option A: Common definitions YAML library (recommended starting point)
+
+Create a `docs/specs/common/` directory with YAML files that define widely-shared settings:
+
+```text
+docs/specs/
+├── common/
+│   ├── gpio.yml       ← GPIO mode, output-type, ospeed, pull-up/down, bit-value
+│   └── spi.yml        ← SPI mode, clock polarity, etc.
+└── stm32/
+    └── stm32u0.yml
+```
+
+A pre-validation script (or a custom `check-jsonschema` hook) merges the common definitions into
+each spec before schema validation. Individual specs retain their own `definitions.settings` for
+family-specific encodings and may override common definitions.
+
+**Pros:**
+
+- Single source of truth for shared settings
+- Easy to audit which families use which common definitions
+- Common definitions are human-readable YAML
+
+**Cons:**
+
+- Requires a merge/preprocessing step before validation; YAML parsers alone cannot resolve
+  cross-file aliases
+- Authors must know which definitions are available in `common/`
+
+---
+
+### Option B: Canonical settings names enforced by the schema
+
+Define a registry of well-known settings names (e.g. `cortex-m-gpio-mode`, `bit-value`) and their
+expected values in the JSON Schema using `$defs`. Validation tools would check that any settings
+block using a canonical name matches the registered definition exactly.
+
+```json
+"$defs": {
+  "canonical-settings": {
+    "cortex-m-gpio-mode": {
+      "00": "input mode",
+      "01": "general purpose output mode",
+      "10": "alternate function mode",
+      "11": "analogue mode"
+    }
+  }
+}
+```
+
+**Pros:**
+
+- No preprocessing step; validation is schema-driven
+- Catches accidental divergence from canonical definitions
+
+**Cons:**
+
+- JSON Schema cannot currently enforce that a YAML alias resolves to a specific named definition;
+  this would require custom validator logic
+- The schema grows large as the canonical registry grows
+
+---
+
+### Option C: Per-vendor schema extension
+
+Each vendor subdirectory could provide a `schema.json` that `allOf`-references the common schema
+and adds vendor-specific constraints (e.g. family name prefix patterns, valid peripheral names).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "allOf": [{ "$ref": "../schema.json" }],
+  "properties": {
+    "vendor": { "const": "STMicroelectronics" },
+    "family": {
+      "properties": {
+        "name": { "pattern": "^stm32" }
+      }
+    }
+  }
+}
+```
+
+The `lint.sh` validation step would look for a vendor-specific `schema.json` first and fall back to
+the common `docs/specs/schema.json` when none exists.
+
+**Pros:**
+
+- Enables vendor-specific validation without modifying the common schema
+- Schema composition is idiomatic JSON Schema
+
+**Cons:**
+
+- Each vendor must maintain a schema extension
+- Does not directly solve cross-file settings sharing
+
+---
+
+### Option D: Spec format versioning
+
+Add a `spec-version` field to every spec file so that tooling can handle multiple format revisions
+gracefully as the format evolves:
+
+```yaml
+spec-version: "1.0"
+vendor: STMicroelectronics
+# ...
+```
+
+This is orthogonal to the sharing options above and should be adopted regardless of which option is
+chosen.
+
+**Pros:**
+
+- Enables non-breaking format evolution
+- Tooling can warn about deprecated keys without failing validation
+
+**Cons:**
+
+- Requires all existing spec files to be updated when a version field is added
+- Version number management adds overhead
+
+---
+
+## Recommendation
+
+1. **Near-term:** Adopt **Option D** (spec-version field) immediately so that format evolution is
+   tracked from the start.
+
+2. **Medium-term:** Implement **Option A** (common definitions library) once more than one vendor's
+   specs exist and duplication is observed. Keep the merge step simple: a small Python script that
+   deep-merges `common/*.yml` definitions into a spec's `definitions.settings` before running
+   `check-jsonschema`.
+
+3. **Long-term:** Consider **Option C** (per-vendor schema extensions) once vendor-specific
+   constraints (e.g. address range validity, peripheral naming conventions) are worth enforcing.
+
+**Option B** (canonical names in schema) is the most powerful approach for enforcing consistency
+but requires custom validator logic that goes beyond standard JSON Schema; defer until there is a
+clear need.

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -34,15 +34,15 @@ the format manageable and the data reusable, three granularity levels should be 
 ```text
 docs/specs/
 ├── schema.json                     ← common JSON Schema (family-level)
-├── schema-model.json               ← JSON Schema for device-model spec files
+├── schema-model.json               ← JSON Schema for device-model spec files ✅
 ├── future_improvements.md
 ├── common/
 │   └── arch/
-│       └── cortex-m0plus.yml       ← architecture-level definitions
+│       └── cortex-m0plus.yml       ← architecture-level definitions ✅
 └── stm32/
     ├── stm32u0.yml                 ← family spec (current)
     └── models/
-        ├── stm32u031c4.yml         ← model spec: 32-pin, 256 KB flash
+        ├── stm32u031c4.yml         ← model spec: UFQFPN32, 256 KB flash ✅ (template)
         ├── stm32u031k4.yml         ← model spec: 32-pin UFQFPN, 256 KB flash
         └── stm32u073rc.yml         ← model spec: 64-pin, 256 KB flash
 ```
@@ -69,7 +69,7 @@ The 11 coverage gaps documented below can now be allocated to the correct level:
 
 | Gap | Title                                         | Level                                                            |
 | --- | --------------------------------------------- | ---------------------------------------------------------------- |
-| 1   | Peripheral instances and base-address binding | Family                                                           |
+| 1   | Peripheral instances and base-address binding | Family ✅                                                        |
 | 2   | Register reset values                         | Family                                                           |
 | 3   | Extended access-type taxonomy                 | Architecture                                                     |
 | 4   | Reserved fields and write-zero constraint     | Architecture                                                     |
@@ -268,24 +268,12 @@ other than GPIO have been deliberately excluded for now and will be added in fut
 items below are therefore _format-level_ gaps — things the spec format itself should eventually
 be able to express regardless of which peripheral is being described.
 
-### 1. Peripheral instances and base-address binding
+### 1. Peripheral instances and base-address binding ✅ (implemented)
 
-The `peripherals` section defines a peripheral's register layout once (e.g. `gpio`), but the
-spec does not link that definition to the concrete memory-map instances (e.g. GPIOA at
-`0x50000000`, GPIOB at `0x50000400`, …). Consumers must manually correlate the two sections.
-
-**Proposed addition:** an `instances` list inside each peripheral entry, each item naming the
-base address from the memory map:
-
-```yaml
-- gpio:
-    instances:
-      - name: GPIOA
-        base: 0x50000000
-      - name: GPIOB
-        base: 0x50000400
-    registers: …
-```
+The `peripherals` section defines a peripheral's register layout once (e.g. `gpio`), and the
+`instances` list inside each peripheral entry binds that layout to the concrete memory-map
+instances (e.g. GPIOA at `0x50000000`, GPIOB at `0x50000400`, …). This removes the need for
+consumers to manually correlate the two sections.
 
 ### 2. Register reset values
 

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -169,3 +169,160 @@ chosen.
 **Option B** (canonical names in schema) is the most powerful approach for enforcing consistency
 but requires custom validator logic that goes beyond standard JSON Schema; defer until there is a
 clear need.
+
+---
+
+## Identified Spec Coverage Gaps
+
+The following areas are not yet captured in the current `stm32u0.yml` specification. Peripherals
+other than GPIO have been deliberately excluded for now and will be added in future updates. The
+items below are therefore _format-level_ gaps — things the spec format itself should eventually
+be able to express regardless of which peripheral is being described.
+
+### 1. Peripheral instances and base-address binding
+
+The `peripherals` section defines a peripheral's register layout once (e.g. `gpio`), but the
+spec does not link that definition to the concrete memory-map instances (e.g. GPIOA at
+`0x50000000`, GPIOB at `0x50000400`, …). Consumers must manually correlate the two sections.
+
+**Proposed addition:** an `instances` list inside each peripheral entry, each item naming the
+base address from the memory map:
+
+```yaml
+- gpio:
+    instances:
+      - name: GPIOA
+        base: 0x50000000
+      - name: GPIOB
+        base: 0x50000400
+    registers: …
+```
+
+### 2. Register reset values
+
+No reset value is recorded for registers. This is essential for:
+
+- Code generation tools that emit `constexpr` register-reset helpers
+- Driver correctness checks that verify hardware is in a known state after reset
+- Documentation that makes the power-on behaviour explicit
+
+**Proposed addition:** an optional `reset-value` (hex string) field on each register entry.
+
+### 3. Extended access-type taxonomy
+
+The current access types (`rw`, `ro`, `wo`) are insufficient for status registers. Many STM32
+and other ARM Cortex-M registers use:
+
+| Access code | Meaning                                     |
+| ----------- | ------------------------------------------- |
+| `rc_w1`     | Read; clear by writing 1                    |
+| `rc_w0`     | Read; clear by writing 0                    |
+| `w1s`       | Write 1 to set (read returns current value) |
+| `w1c`       | Write 1 to clear                            |
+| `rs`        | Read/set (writing has no effect)            |
+| `t`         | Toggle (write 1 to toggle current value)    |
+
+Without these access types, driver code generation is incomplete and consumers cannot determine
+the correct RMW strategy for each field.
+
+**Proposed addition:** expand the `access` enum in the schema to include the above codes, and
+document each in the README.
+
+### 4. Reserved fields and write-zero constraint
+
+Reserved bits within a register are partially expressed (e.g. `RESERVED` fields in LCKR), but
+there is no way to specify the required write behaviour (`write-zero`, `write-as-read`,
+`write-any`). Incorrect writes to reserved bits can cause undefined hardware behaviour.
+
+**Proposed addition:** an optional `reserved-write` field on `RESERVED`-named register entries:
+
+```yaml
+- name: RESERVED
+  msb: 31
+  lsb: 17
+  access: ro
+  reserved-write: write-zero
+```
+
+### 5. Sub-family conditional registers and fields
+
+The `sub-families` applicability key exists in the memory map but is absent from individual
+registers and fields. Some STM32U0 registers or bit fields may be absent or have different reset
+values on stm32u031 versus stm32u073/u083.
+
+**Proposed addition:** allow an optional `sub-families` list on register and field entries,
+mirroring the memory-map convention.
+
+### 6. Alternate function pin-mapping table
+
+The `afsel` settings block names AF0–AF15 symbolically but does not record the actual function
+assigned to each (alternate function, pin) pair (e.g. PA0+AF1 = `TIM2_CH1`). This table is the
+primary information a developer needs when selecting GPIO alternate functions.
+
+**Proposed addition:** a separate top-level `pin-functions` section (or a `functions` key inside
+each GPIO instance) that maps `{pin, af-number}` → function-name string, cross-referenced to the
+reference manual's alternate-function table.
+
+### 7. Clock gating and power-domain metadata
+
+No information is recorded about which RCC enable bit must be set before a peripheral can be
+accessed, or which power domain (VDD, VDDIO, independent) the peripheral belongs to. This is
+needed for correct peripheral initialisation sequences and low-power mode driver code.
+
+**Proposed addition:** an optional `clock` mapping on each peripheral instance:
+
+```yaml
+instances:
+  - name: GPIOA
+    base: 0x50000000
+    clock:
+      bus: AHB
+      enable-register: RCC_IOPENR
+      enable-bit: GPIOAEN
+```
+
+### 8. Interrupt mapping
+
+No way to express which interrupt lines a peripheral raises or what conditions trigger them. This
+is needed to generate NVIC priority and enable configuration.
+
+**Proposed addition:** an optional `interrupts` list on each peripheral instance:
+
+```yaml
+interrupts:
+  - name: EXTI0_1
+    irq-number: 5
+    trigger: rising or falling edge on EXTI lines 0–1
+```
+
+### 9. Errata and silicon-revision annotations
+
+Known hardware bugs that affect driver implementation are not captured. Without this information,
+spec consumers cannot generate workarounds automatically.
+
+**Proposed addition:** an optional top-level `errata` section listing known issues with their
+affected silicon revisions, an informal description, and a workaround reference:
+
+```yaml
+errata:
+  - id: STM32U0-ERRATA-001
+    title: LCKR lock sequence may fail when …
+    affected-revisions: [rev-A]
+    workaround: Insert a DSB instruction between the second and third LCKR writes.
+    reference: STM32U0 Errata sheet ES0561 §2.3.1
+```
+
+### 10. Register-array and stride notation
+
+DMA, timers, and other peripherals expose arrays of identical register sets (e.g. DMA channels
+0–7 each with CCR/CNDTR/CPAR/CMAR at a fixed stride). The current format has no way to express
+this; each channel would have to be listed individually.
+
+**Proposed addition:** an optional `count` and `stride` on a register-group entry, allowing
+concise description of repeated register blocks.
+
+### 11. Peripheral description field
+
+The `gpio` peripheral entry has no human-readable `description` field. Adding one (mirroring the
+`note` field available on individual registers and fields) would make the spec self-contained as
+reference documentation without requiring the reader to consult the reference manual.

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -130,10 +130,10 @@ the common `docs/specs/schema.json` when none exists.
 ### Option D: Spec format versioning ✅ (implemented)
 
 A `spec-version` field has been added to every spec file. The field is required by the schema and
-uses `MAJOR.MINOR` semantics:
+uses [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
 
 ```yaml
-spec-version: "1.0"
+spec-version: "1.0.0"
 vendor: STMicroelectronics
 # ...
 ```
@@ -156,7 +156,7 @@ chosen.
 ## Recommendation
 
 1. **Near-term:** ~~Adopt **Option D** (spec-version field) immediately so that format evolution is
-   tracked from the start.~~ ✅ Implemented — `spec-version: "1.0"` is now required by the schema.
+   tracked from the start.~~ ✅ Implemented — `spec-version: "1.0.0"` (semver) is now required by the schema.
 
 2. **Medium-term:** Implement **Option A** (common definitions library) once more than one vendor's
    specs exist and duplication is observed. Keep the merge step simple: a small Python script that

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -1,11 +1,100 @@
-# Future Improvements: Cross-Family and Cross-Vendor Settings Sharing
+# Future Improvements
+
+## Specification Granularity Levels
+
+The longer-term plan is for specifications to cover not just memory maps and peripheral register
+layouts but also device-model-specific information such as alternate-function pin mappings. To keep
+the format manageable and the data reusable, three granularity levels should be kept separate:
+
+| Level            | What it describes                                                                                          | Expected file                                       |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Architecture** | Word size, endianness, register access type taxonomy, core peripherals (NVIC, SysTick, SCB)                | `docs/specs/common/arch/{arch}.yml`                 |
+| **Family**       | Memory map, peripheral register layouts, clock gating structure, sub-family differences                    | `docs/specs/{vendor}/{family}.yml` (current format) |
+| **Device model** | Specific part number, package, pin count, alternate-function table, available peripheral instances, errata | `docs/specs/{vendor}/models/{part-number}.yml`      |
+
+### Why three levels?
+
+- **Architecture** data is entirely vendor-independent. The ARM Cortex-M0+ access-type taxonomy
+  (`rc_w1`, `w1s`, etc.), NVIC register layout, and word size apply identically to STM32, NXP LPC,
+  Nordic nRF, and any other Cortex-M0+ device. Storing it once avoids duplication and drift.
+
+- **Family** data is shared across all models in a family. The STM32U0 GPIO register layout (MODER,
+  OTYPER, OSPEEDR, …) is the same for every stm32u031, stm32u073, and stm32u083 part. Clock gating
+  register names (e.g. `RCC_IOPENR.GPIOAEN`) are family-level even though each model may expose a
+  different subset of GPIO ports. This is what the current spec file captures.
+
+- **Device model** data is specific to a single part number or package variant. The alternate-function
+  mapping for PA0 differs between a 32-pin UFQFPN and a 48-pin LQFP package of the same family.
+  Errata are tied to silicon revision. The list of available GPIO ports (and hence which peripheral
+  instances exist) changes between stm32u031C4 and stm32u031K4. Conflating this with family-level
+  data would force the family spec to enumerate every part-specific variant.
+
+### Proposed directory layout
+
+```text
+docs/specs/
+├── schema.json                     ← common JSON Schema (family-level)
+├── schema-model.json               ← JSON Schema for device-model spec files
+├── future_improvements.md
+├── common/
+│   └── arch/
+│       └── cortex-m0plus.yml       ← architecture-level definitions
+└── stm32/
+    ├── stm32u0.yml                 ← family spec (current)
+    └── models/
+        ├── stm32u031c4.yml         ← model spec: 32-pin, 256 KB flash
+        ├── stm32u031k4.yml         ← model spec: 32-pin UFQFPN, 256 KB flash
+        └── stm32u073rc.yml         ← model spec: 64-pin, 256 KB flash
+```
+
+### Cross-level references
+
+A model spec references its parent family spec via a `family-ref` key. Tooling can then merge the
+two levels when generating code or documentation:
+
+```yaml
+spec-version: "1.0.0"
+vendor: STMicroelectronics
+family-ref: stm32u0 # links back to stm32u0.yml
+model: stm32u031c4
+package: UFQFPN32
+flash-kb: 256
+sram-kb: 12
+pin-count: 32
+```
+
+### Mapping the identified coverage gaps to levels
+
+The 11 coverage gaps documented below can now be allocated to the correct level:
+
+| Gap | Title                                         | Level                                                            |
+| --- | --------------------------------------------- | ---------------------------------------------------------------- |
+| 1   | Peripheral instances and base-address binding | Family                                                           |
+| 2   | Register reset values                         | Family                                                           |
+| 3   | Extended access-type taxonomy                 | Architecture                                                     |
+| 4   | Reserved fields and write-zero constraint     | Architecture                                                     |
+| 5   | Sub-family conditional registers/fields       | Family                                                           |
+| 6   | Alternate function pin-mapping table          | **Model**                                                        |
+| 7   | Clock gating and power-domain metadata        | Family                                                           |
+| 8   | Interrupt mapping                             | Family (base IRQ numbers) + **Model** (availability per package) |
+| 9   | Errata and silicon-revision annotations       | **Model**                                                        |
+| 10  | Register-array and stride notation            | Family                                                           |
+| 11  | Peripheral description field                  | Family                                                           |
+
+Gaps marked **Model** should be deferred until `schema-model.json` and the `models/` directory
+structure are introduced. The remaining gaps can be addressed incrementally in the existing family
+spec format.
+
+---
+
+## Cross-Family and Cross-Vendor Settings Sharing
 
 The current spec format stores all `definitions.settings` blocks inside individual spec files. This
 works well for a single family but leads to duplication when the same settings encoding appears
 across multiple families or vendors. This document describes the problem and evaluates options for
 addressing it.
 
-## Problem
+### Problem
 
 Many peripheral settings encodings are identical across device families and even across vendors,
 because they implement the same IP (e.g. ARM Cortex-M GPIO) or follow the same de-facto convention:
@@ -21,13 +110,13 @@ because they implement the same IP (e.g. ARM Cortex-M GPIO) or follow the same d
 When the same settings block is copy-pasted into every spec file, a typo or update must be applied
 to every copy. A shared definitions mechanism would provide a single source of truth.
 
-## Constraints
+### Constraints
 
 The spec format is plain YAML. YAML 1.2 (and YAML 1.1) have no built-in cross-file `include` or
 `$ref`. Any cross-file sharing therefore requires either tooling support or a change in the
 validation strategy.
 
-## Options
+### Options
 
 ### Option A: Common definitions YAML library (recommended starting point)
 
@@ -153,7 +242,7 @@ chosen.
 
 ---
 
-## Recommendation
+### Recommendation
 
 1. **Near-term:** ~~Adopt **Option D** (spec-version field) immediately so that format evolution is
    tracked from the start.~~ ✅ Implemented — `spec-version: "1.0.0"` (semver) is now required by the schema.

--- a/docs/specs/future_improvements.md
+++ b/docs/specs/future_improvements.md
@@ -127,10 +127,10 @@ the common `docs/specs/schema.json` when none exists.
 
 ---
 
-### Option D: Spec format versioning
+### Option D: Spec format versioning ✅ (implemented)
 
-Add a `spec-version` field to every spec file so that tooling can handle multiple format revisions
-gracefully as the format evolves:
+A `spec-version` field has been added to every spec file. The field is required by the schema and
+uses `MAJOR.MINOR` semantics:
 
 ```yaml
 spec-version: "1.0"
@@ -155,8 +155,8 @@ chosen.
 
 ## Recommendation
 
-1. **Near-term:** Adopt **Option D** (spec-version field) immediately so that format evolution is
-   tracked from the start.
+1. **Near-term:** ~~Adopt **Option D** (spec-version field) immediately so that format evolution is
+   tracked from the start.~~ ✅ Implemented — `spec-version: "1.0"` is now required by the schema.
 
 2. **Medium-term:** Implement **Option A** (common definitions library) once more than one vendor's
    specs exist and duplication is observed. Keep the merge step simple: a small Python script that

--- a/docs/specs/schema-arch.json
+++ b/docs/specs/schema-arch.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/grahame-org/ohal/blob/main/docs/specs/schema-arch.json",
+  "title": "Processor architecture specification",
+  "description": "Schema for architecture-level spec files in docs/specs/common/arch/. An architecture spec captures metadata that is identical on every device implementing that processor architecture: word size, endianness, Private Peripheral Bus (PPB) address regions, and settings encodings shared by all devices of that architecture.",
+  "type": "object",
+  "required": ["spec-version", "architecture"],
+  "additionalProperties": false,
+  "properties": {
+    "spec-version": {
+      "description": "Spec format version using semantic versioning (semver), e.g. '1.0.0'. Increment the patch version for corrections, the minor version for backward-compatible additions, and the major version for breaking changes.",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "architecture": {
+      "description": "Processor architecture metadata.",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Architecture name, e.g. 'ARM Cortex-M0+'.",
+          "type": "string"
+        },
+        "word-size": {
+          "description": "Native word size in bits.",
+          "type": "integer",
+          "enum": [8, 16, 32, 64]
+        },
+        "endianness": {
+          "description": "Byte order of the architecture.",
+          "type": "string",
+          "enum": ["little", "big"]
+        }
+      }
+    },
+    "memory": {
+      "description": "Architecture-defined memory regions (e.g. Private Peripheral Bus). These regions are identical on every device implementing this architecture.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "note": {
+          "description": "Optional free-text annotation for the architecture memory section.",
+          "type": "string"
+        },
+        "map": {
+          "description": "List of architecture-defined memory regions.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/arch-memory-region" }
+        }
+      }
+    },
+    "definitions": {
+      "description": "Reusable definitions shared across all devices of this architecture. Values are referenced via YAML anchors/aliases in family specs.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "settings": {
+          "description": "Named settings maps that are architecturally defined and identical across all devices. Keys are settings-block names; values are the bit-pattern-to-description mappings.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/settings" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "hex-address": {
+      "description": "A hex address or byte offset (e.g. 0x40000000). Written in hex notation in the source YAML; parsed as an integer by most YAML parsers.",
+      "type": ["string", "integer"]
+    },
+    "settings": {
+      "description": "Enumerated bit-pattern settings for a field. Keys are binary bit patterns (e.g. '00', '10', '1111'). Null means no settings are documented.",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      ]
+    },
+    "arch-memory-region": {
+      "description": "A named architecture-defined address range.",
+      "type": "object",
+      "required": ["name", "start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "start": { "$ref": "#/$defs/hex-address" },
+        "end": { "$ref": "#/$defs/hex-address" },
+        "note": {
+          "description": "Optional free-text annotation.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/schema-model.json
+++ b/docs/specs/schema-model.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/grahame-org/ohal/blob/main/docs/specs/schema-model.json",
+  "title": "Microcontroller device-model specification",
+  "description": "Schema for device-model spec files. A model spec describes a specific part number (e.g. stm32u031c4), including its package, memory sizes, available peripheral instances, alternate-function pin mappings, and errata. It references its parent family spec via 'family-ref'.",
+  "type": "object",
+  "required": ["spec-version", "vendor", "family-ref", "model", "package", "flash-kb", "sram-kb", "pin-count"],
+  "additionalProperties": false,
+  "properties": {
+    "spec-version": {
+      "description": "Spec format version using semantic versioning (semver), e.g. '1.0.0'. Increment the patch version for corrections, the minor version for backward-compatible additions, and the major version for breaking changes.",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "vendor": {
+      "description": "Chip vendor name, e.g. 'STMicroelectronics'. Must match the vendor field in the referenced family spec.",
+      "type": "string"
+    },
+    "family-ref": {
+      "description": "Family spec identifier (without the .yml extension), e.g. 'stm32u0'. Tooling resolves this to docs/specs/{vendor-dir}/{family-ref}.yml.",
+      "type": "string"
+    },
+    "model": {
+      "description": "Part number identifier in lowercase, e.g. 'stm32u031c4'. Must match the filename (without .yml extension).",
+      "type": "string"
+    },
+    "package": {
+      "description": "Package code as used in the part number suffix, e.g. 'UFQFPN32', 'LQFP48', 'WLCSP25'.",
+      "type": "string"
+    },
+    "flash-kb": {
+      "description": "On-chip flash memory size in kibibytes.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "sram-kb": {
+      "description": "On-chip SRAM size in kibibytes (total, across all SRAM banks).",
+      "type": "integer",
+      "minimum": 1
+    },
+    "pin-count": {
+      "description": "Total number of pins on the physical package.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "peripheral-availability": {
+      "description": "Lists which peripheral instances from the family spec are present on this device. Omit for instances that are unavailable (e.g. absent GPIO ports on smaller packages).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/peripheral-availability-entry" },
+      "minItems": 1
+    },
+    "alternate-functions": {
+      "description": "Alternate-function pin-mapping table for this specific model and package. Each entry maps a pin name to its available alternate functions.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/pin-af-entry" },
+      "minItems": 1
+    },
+    "errata": {
+      "description": "Known hardware errata for this silicon. Each entry has a title, a description, and an optional silicon-revision applicability list.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/erratum" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "peripheral-availability-entry": {
+      "description": "Records which instances of a given peripheral type are present on this device model.",
+      "type": "object",
+      "required": ["peripheral", "instances"],
+      "additionalProperties": false,
+      "properties": {
+        "peripheral": {
+          "description": "Peripheral type name as it appears in the family spec (e.g. 'gpio', 'usart').",
+          "type": "string"
+        },
+        "instances": {
+          "description": "List of instance names (e.g. 'GPIOA', 'GPIOB') that are present on this device model.",
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+    "pin-af-entry": {
+      "description": "Alternate-function assignments for a single pin.",
+      "type": "object",
+      "required": ["pin", "functions"],
+      "additionalProperties": false,
+      "properties": {
+        "pin": {
+          "description": "Pin name in the form 'P{port}{number}', e.g. 'PA0', 'PB13'.",
+          "type": "string",
+          "pattern": "^P[A-Z][0-9]{1,2}$"
+        },
+        "functions": {
+          "description": "Mapping from AF code (AF0–AF15) to the signal name assigned to that AF on this pin (e.g. 'TIM2_CH1', 'USART1_TX'). Use null for AF slots that are not assigned.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "oneOf": [{ "type": "string" }, { "type": "null" }]
+          }
+        }
+      }
+    },
+    "erratum": {
+      "description": "A single hardware erratum.",
+      "type": "object",
+      "required": ["id", "title", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Vendor erratum identifier (e.g. 'ES0561-2.1.1').",
+          "type": "string"
+        },
+        "title": {
+          "description": "Short title of the erratum.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Full description of the erratum including workaround if known.",
+          "type": "string"
+        },
+        "silicon-revisions": {
+          "description": "Silicon revision codes to which this erratum applies (e.g. ['A', 'B']). Omit if the erratum applies to all known revisions.",
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -34,6 +34,10 @@
         }
       }
     },
+    "arch-ref": {
+      "description": "Identifier of the architecture-level spec file (without the .yml extension) in docs/specs/common/arch/, e.g. 'cortex-m0plus'. Tooling can merge the referenced architecture spec with this family spec when generating code or documentation.",
+      "type": "string"
+    },
     "architecture": {
       "description": "Processor architecture metadata.",
       "type": "object",

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -4,9 +4,14 @@
   "title": "Microcontroller device-family register specification",
   "description": "Vendor-agnostic schema for microcontroller device-family register-map and peripheral register/field metadata.",
   "type": "object",
-  "required": ["vendor", "family", "architecture", "reference"],
+  "required": ["spec-version", "vendor", "family", "architecture", "reference"],
   "additionalProperties": false,
   "properties": {
+    "spec-version": {
+      "description": "Spec format version, e.g. '1.0'. Increment the minor version for backward-compatible additions, the major version for breaking changes.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
     "vendor": {
       "description": "Chip vendor name, e.g. 'STMicroelectronics', 'Nordic Semiconductor', 'NXP'.",
       "type": "string"

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/grahame-org/ohal/blob/main/docs/specs/stm32/schema.json",
-  "title": "STM32 device-family register specification",
-  "description": "Schema for STM32 device-family register-map and peripheral register/field metadata.",
+  "$id": "https://github.com/grahame-org/ohal/blob/main/docs/specs/schema.json",
+  "title": "Microcontroller device-family register specification",
+  "description": "Vendor-agnostic schema for microcontroller device-family register-map and peripheral register/field metadata.",
   "type": "object",
-  "required": ["family", "architecture", "reference"],
+  "required": ["vendor", "family", "architecture", "reference"],
   "additionalProperties": false,
   "properties": {
+    "vendor": {
+      "description": "Chip vendor name, e.g. 'STMicroelectronics', 'Nordic Semiconductor', 'NXP'.",
+      "type": "string"
+    },
     "family": {
       "description": "Device family metadata.",
       "type": "object",

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -8,9 +8,9 @@
   "additionalProperties": false,
   "properties": {
     "spec-version": {
-      "description": "Spec format version, e.g. '1.0'. Increment the minor version for backward-compatible additions, the major version for breaking changes.",
+      "description": "Spec format version using semantic versioning (semver), e.g. '1.0.0'. Increment the patch version for corrections, the minor version for backward-compatible additions, and the major version for breaking changes.",
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+$"
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
     "vendor": {
       "description": "Chip vendor name, e.g. 'STMicroelectronics', 'Nordic Semiconductor', 'NXP'.",

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -144,6 +144,14 @@
         },
         "start": { "$ref": "#/$defs/hex-address" },
         "end": { "$ref": "#/$defs/hex-address" },
+        "base": {
+          "description": "Peripheral base address for register offset calculations, when it differs from the region's start address. Consumers should use this address (not start) when computing register addresses from offsets.",
+          "$ref": "#/$defs/hex-address"
+        },
+        "verified": {
+          "description": "Whether this entry has been verified against the reference manual. Defaults to true. Set to false to flag data that is provisional or still needs checking.",
+          "type": "boolean"
+        },
         "note": {
           "description": "Optional free-text annotation.",
           "type": "string"
@@ -196,6 +204,12 @@
         "note": {
           "description": "Optional free-text annotation for this field.",
           "type": "string"
+        },
+        "priority-over": {
+          "description": "Names of fields in the same register that this field overrides when both are written in the same register access. If this field and any listed field are both written with a non-zero value simultaneously, the effect of this field takes precedence and the listed fields' writes are ignored by the hardware.",
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
         },
         "settings": { "$ref": "#/$defs/settings" }
       }

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -291,11 +291,38 @@
       "additionalProperties": false,
       "properties": {
         "reference": { "$ref": "#/$defs/references" },
+        "instances": {
+          "description": "Concrete instances of this peripheral in the device memory map, each binding the register layout to a named base address.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/peripheral-instance" },
+          "minItems": 1
+        },
         "registers": {
           "description": "Ordered list of register definitions. Each item is a single-key mapping whose key is the register name.",
           "type": "array",
           "items": { "$ref": "#/$defs/register-item" },
           "minItems": 1
+        }
+      }
+    },
+    "peripheral-instance": {
+      "description": "A named instance of a peripheral at a specific base address.",
+      "type": "object",
+      "required": ["name", "base"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Instance name as it appears in the reference manual, e.g. 'GPIOA', 'TIM2'.",
+          "type": "string"
+        },
+        "base": {
+          "description": "Base address of this peripheral instance.",
+          "$ref": "#/$defs/hex-address"
+        },
+        "sub-families": {
+          "description": "Sub-families for which this instance is present. Omit if the instance is present in all sub-families.",
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -196,25 +196,68 @@
         "settings": { "$ref": "#/$defs/settings" }
       }
     },
-    "sequence-step": {
-      "description": "A single read or write step in a register access sequence.",
+    "sequence": {
+      "description": "Required access sequence (e.g. lock/unlock procedure).",
       "type": "object",
+      "required": ["description", "steps"],
       "additionalProperties": false,
       "properties": {
-        "write": {
+        "description": {
+          "description": "Human-readable explanation of when/why this sequence is required, and any caller arguments it accepts (e.g. 'write-arg' values).",
+          "type": "string"
+        },
+        "steps": {
+          "description": "Ordered list of steps. Steps must be executed in the order listed.",
           "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": { "type": ["string", "integer"] }
+          "items": { "$ref": "#/$defs/sequence-step" },
+          "minItems": 2
+        }
+      }
+    },
+    "sequence-step": {
+      "description": "A single step in a register access sequence.",
+      "type": "object",
+      "required": ["op"],
+      "additionalProperties": false,
+      "properties": {
+        "op": {
+          "description": "Operation type: 'write' writes field values to the register; 'read' reads the register.",
+          "type": "string",
+          "enum": ["read", "write"]
+        },
+        "note": {
+          "description": "Human-readable explanation of this step's purpose, including any timing or ordering constraints.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Whether this step may be omitted. Defaults to false. Optional steps should still be executed when possible.",
+          "type": "boolean"
+        },
+        "fields": {
+          "description": "Field values to write. Keys are field names (or logical field groups). Values are either a non-negative integer literal (fixed value) or the string 'write-arg' (caller-supplied value). Only valid when op is 'write'.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "oneOf": [
+              { "type": "integer", "minimum": 0 },
+              { "type": "string", "const": "write-arg" }
+            ]
           }
         },
-        "read": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": { "type": ["string", "integer"] }
-          }
+        "expect": {
+          "description": "Expected field values to verify after reading. Keys are field names; values are the expected non-negative integers representing the field's bit pattern. A consumer should check these values and treat a mismatch as a sequence failure. Omit on read steps where the result is intentionally discarded. Only valid when op is 'read'.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "type": "integer", "minimum": 0 }
         }
+      },
+      "if": { "properties": { "op": { "const": "write" } }, "required": ["op"] },
+      "then": {
+        "required": ["fields"],
+        "not": { "required": ["expect"] }
+      },
+      "else": {
+        "not": { "required": ["fields"] }
       }
     },
     "register": {
@@ -228,11 +271,7 @@
           "description": "Register byte offset from the peripheral base address.",
           "$ref": "#/$defs/hex-address"
         },
-        "sequence": {
-          "description": "Required access sequence (e.g. lock/unlock procedure).",
-          "type": "array",
-          "items": { "$ref": "#/$defs/sequence-step" }
-        },
+        "sequence": { "$ref": "#/$defs/sequence" },
         "fields": {
           "description": "Ordered list of bit-fields from MSB to LSB.",
           "type": "array",

--- a/docs/specs/schema.json
+++ b/docs/specs/schema.json
@@ -145,7 +145,7 @@
         "start": { "$ref": "#/$defs/hex-address" },
         "end": { "$ref": "#/$defs/hex-address" },
         "base": {
-          "description": "Peripheral base address for register offset calculations, when it differs from the region's start address. Consumers should use this address (not start) when computing register addresses from offsets.",
+          "description": "Peripheral base address for register offset calculations, when it differs from the region's start address. Consumers must use this address (not start) when computing register addresses from offsets.",
           "$ref": "#/$defs/hex-address"
         },
         "verified": {
@@ -206,7 +206,7 @@
           "type": "string"
         },
         "priority-over": {
-          "description": "Names of fields in the same register that this field overrides when both are written in the same register access. If this field and any listed field are both written with a non-zero value simultaneously, the effect of this field takes precedence and the listed fields' writes are ignored by the hardware.",
+          "description": "Names of fields that this field overrides when both are written in the same register access. If this field and any listed field are both written with a non-zero value simultaneously, the effect of this field takes precedence and the listed fields' writes are ignored by the hardware.",
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1

--- a/docs/specs/stm32/models/stm32u031c4.yml
+++ b/docs/specs/stm32/models/stm32u031c4.yml
@@ -1,0 +1,66 @@
+---
+spec-version: "1.0.0"
+vendor: STMicroelectronics
+family-ref: stm32u0
+model: stm32u031c4
+package: UFQFPN32
+flash-kb: 256
+sram-kb: 12
+pin-count: 32
+peripheral-availability:
+  - peripheral: gpio
+    instances: [GPIOA, GPIOB, GPIOC, GPIOD, GPIOF]
+    # Note: GPIOE is not bonded out on the 32-pin UFQFPN package.
+alternate-functions:
+  # Excerpt: PA0–PA3 with their AF0–AF7 assignments.
+  # A complete table covers all GPIOs; see RM0503 Table 17.
+  - pin: PA0
+    functions:
+      AF0: ~
+      AF1: TIM2_CH1
+      AF2: TIM2_ETR
+      AF3: ~
+      AF4: USART2_CTS
+      AF5: ~
+      AF6: LPUART1_RX
+      AF7: COMP1_OUT
+  - pin: PA1
+    functions:
+      AF0: ~
+      AF1: TIM2_CH2
+      AF2: ~
+      AF3: ~
+      AF4: USART2_RTS_DE
+      AF5: ~
+      AF6: LPUART1_TX
+      AF7: ~
+  - pin: PA2
+    functions:
+      AF0: ~
+      AF1: TIM2_CH3
+      AF2: ~
+      AF3: ~
+      AF4: USART2_TX
+      AF5: ~
+      AF6: LPUART2_TX
+      AF7: COMP2_OUT
+  - pin: PA3
+    functions:
+      AF0: ~
+      AF1: TIM2_CH4
+      AF2: TIM15_CH2
+      AF3: ~
+      AF4: USART2_RX
+      AF5: ~
+      AF6: LPUART2_RX
+      AF7: ~
+errata:
+  # This section is intentionally sparse; a production spec would list all applicable
+  # errata from the STM32U031 errata sheet (ES0561).
+  - id: ES0561-2.1.1
+    title: HSI16 clock drift at low supply voltage
+    description: >-
+      Under certain supply voltage and temperature conditions the HSI16 oscillator frequency may
+      deviate beyond the specified accuracy. Workaround: use an external crystal oscillator (HSE)
+      when high frequency accuracy is required at low supply voltage.
+    silicon-revisions: [A]

--- a/docs/specs/stm32/schema.json
+++ b/docs/specs/stm32/schema.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/grahame-org/ohal/blob/main/docs/specs/stm32/schema.json",
+  "title": "STM32 device-family register specification",
+  "description": "Schema for STM32 device-family register-map and peripheral register/field metadata.",
+  "type": "object",
+  "required": ["family", "architecture", "reference"],
+  "additionalProperties": false,
+  "properties": {
+    "family": {
+      "description": "Device family metadata.",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Family identifier, e.g. 'stm32u0'.",
+          "type": "string"
+        },
+        "sub-families": {
+          "description": "List of sub-family identifiers that belong to this family.",
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    },
+    "architecture": {
+      "description": "Processor architecture metadata.",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Architecture name, e.g. 'ARM Cortex-M0+'.",
+          "type": "string"
+        },
+        "word-size": {
+          "description": "Native word size in bits.",
+          "type": "integer",
+          "enum": [8, 16, 32, 64]
+        }
+      }
+    },
+    "reference": {
+      "description": "Reference manual metadata.",
+      "type": "object",
+      "required": ["source", "revision"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "description": "Reference manual document identifier, e.g. 'RM0503'.",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Reference manual revision number.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "memory": {
+      "description": "Memory map.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "references": { "$ref": "#/$defs/references" },
+        "map": {
+          "description": "List of memory regions.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/memory-region" }
+        }
+      }
+    },
+    "definitions": {
+      "description": "Reusable definitions. Values are referenced via YAML anchors/aliases in the spec.",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Named settings maps, each referenced by one or more fields.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/settings" }
+        }
+      }
+    },
+    "peripherals": {
+      "description": "List of peripheral blocks documented in this spec.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/peripheral-item" }
+    }
+  },
+  "$defs": {
+    "hex-address": {
+      "description": "A hex address or byte offset (e.g. 0x40000000). Written in hex notation in the source YAML; parsed as an integer by most YAML parsers.",
+      "type": ["string", "integer"]
+    },
+    "references": {
+      "description": "Cross-references into the source reference manual.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "section": {
+          "description": "Single section reference (used by individual registers).",
+          "type": ["string", "number"]
+        },
+        "sections": {
+          "description": "Multiple section references.",
+          "type": "array",
+          "items": { "type": ["string", "number"] }
+        },
+        "figures": {
+          "type": "array",
+          "items": { "type": ["string", "number"] }
+        },
+        "tables": {
+          "type": "array",
+          "items": { "type": ["string", "number"] }
+        }
+      }
+    },
+    "memory-region": {
+      "description": "A named address range in the memory map.",
+      "type": "object",
+      "required": ["name", "start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "sub-families": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "start": { "$ref": "#/$defs/hex-address" },
+        "end": { "$ref": "#/$defs/hex-address" },
+        "note": {
+          "description": "Optional free-text annotation.",
+          "type": "string"
+        }
+      }
+    },
+    "settings": {
+      "description": "Enumerated bit-pattern settings for a field. Keys are binary bit patterns (e.g. '00', '10', '1111'). Null means no settings are documented.",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      ]
+    },
+    "field": {
+      "description": "A named bit-field within a register.",
+      "type": "object",
+      "required": ["name", "msb", "lsb", "width", "access", "settings"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Field name as it appears in the reference manual.",
+          "type": "string"
+        },
+        "msb": {
+          "description": "Most-significant bit position (inclusive, 0-based).",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 63
+        },
+        "lsb": {
+          "description": "Least-significant bit position (inclusive, 0-based).",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 63
+        },
+        "width": {
+          "description": "Field width in bits (must equal msb - lsb + 1).",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "access": {
+          "description": "Register access type: rw = read/write, ro = read-only, wo = write-only.",
+          "type": "string",
+          "enum": ["rw", "ro", "wo"]
+        },
+        "note": {
+          "description": "Optional free-text annotation for this field.",
+          "type": "string"
+        },
+        "settings": { "$ref": "#/$defs/settings" }
+      }
+    },
+    "sequence-step": {
+      "description": "A single read or write step in a register access sequence.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "write": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": { "type": ["string", "integer"] }
+          }
+        },
+        "read": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": { "type": ["string", "integer"] }
+          }
+        }
+      }
+    },
+    "register": {
+      "description": "A hardware register definition.",
+      "type": "object",
+      "required": ["offset", "fields"],
+      "additionalProperties": false,
+      "properties": {
+        "reference": { "$ref": "#/$defs/references" },
+        "offset": {
+          "description": "Register byte offset from the peripheral base address.",
+          "$ref": "#/$defs/hex-address"
+        },
+        "sequence": {
+          "description": "Required access sequence (e.g. lock/unlock procedure).",
+          "type": "array",
+          "items": { "$ref": "#/$defs/sequence-step" }
+        },
+        "fields": {
+          "description": "Ordered list of bit-fields from MSB to LSB.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/field" },
+          "minItems": 1
+        }
+      }
+    },
+    "peripheral": {
+      "description": "A peripheral block containing registers.",
+      "type": "object",
+      "required": ["registers"],
+      "additionalProperties": false,
+      "properties": {
+        "reference": { "$ref": "#/$defs/references" },
+        "registers": {
+          "description": "Ordered list of register definitions. Each item is a single-key mapping whose key is the register name.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/register-item" },
+          "minItems": 1
+        }
+      }
+    },
+    "register-item": {
+      "description": "A single-key mapping where the key is the register name and the value is the register definition.",
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/register" }
+    },
+    "peripheral-item": {
+      "description": "A single-key mapping where the key is the peripheral name and the value is the peripheral definition.",
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/peripheral" }
+    }
+  }
+}

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -534,6 +534,19 @@ peripherals:
       reference:
         sections: [2.2, 7.4, 7.4.12]
         tables: [4, 41]
+      instances:
+        - name: GPIOA
+          base: 0x50000000
+        - name: GPIOB
+          base: 0x50000400
+        - name: GPIOC
+          base: 0x50000800
+        - name: GPIOD
+          base: 0x50000C00
+        - name: GPIOE
+          base: 0x50001000
+        - name: GPIOF
+          base: 0x50001400
       registers:
         - MODER:
             reference:

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -87,7 +87,7 @@ memory:
       end: 0x20009FFF
       verified: false
       note: >-
-        Table 2 of RM0503 does not document this address range: stm32u031 SRAM ends at
+        Table 3 of RM0503 does not document this address range: stm32u031 SRAM ends at
         0x20002FFF and the next listed region starts at 0x2000A000, leaving this gap unlabelled.
         Assumed reserved until a citable reference is located.
     - name: SRAM

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1,0 +1,2345 @@
+---
+family: stm32u0
+  sub-families: [stm32u031, stm32u073, stm32u083]
+architecture: ARM cortex M0+
+  word-size: 32
+reference:
+  source: RM0503
+  revision: 4
+memory:
+  references:
+    sections: [2.2.2]
+    figures: [2]
+    tables: [2, 3, 4]
+  map:
+    - name: block 0
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x00000000
+      end:   0x1FFFFFFF
+    - name: Main flash memory,  System memory or SRAM. Depends on boot configuration
+      sub-families: [stm32u031]
+      start: 0x00000000
+      end: 0x0001FFFF
+    - name: Main flash memory,  System memory or SRAM. Depends on boot configuration
+      sub-families: [stm32u073, stm32u083]
+      start: 0x00000000
+      end: 0x0003FFFF
+    - name: reserved
+      sub-families: [stm32u031]
+      start: 0x00020000
+      end: 0x07FFFFFF
+    - name: reserved
+      sub-families: [stm32u073, stm32u083]
+      start: 0x00080000
+      end: 0x07FFFFFF
+    - name: Main flash memory
+      sub-families: [stm32u031]
+      start: 0x08000000
+      end: 0x0801FFFF
+    - name: Main flash memory
+      sub-families: [stm32u073, stm32u083]
+      start: 0x08000000
+      end: 0x0803FFFF
+    - name: reserved
+      sub-families: [stm32u031]
+      start: 0x08020000
+      end: 0x1FFFD7FF
+    - name: reserved
+      sub-families: [stm32u073, stm32u083]
+      start: 0x08080000
+      end: 0x1FFFD7FF
+    - name: System memory
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x1FFF0000
+      end: 0x1FFF67FF
+    - name: OTP
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x1FFF6800
+      end: 0x1FFF6BFF
+    - name: Engineering bytes
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x1FFF6C00
+      end: 0x1FFF6FFF
+    - name: Option bytes
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x1FFF7000
+      end: 0x1FFF7FFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x1FFF8000
+      end: 0x1FFFFFFF
+    - name: block 1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x20000000
+      end:   0x3FFFFFFF
+    - name: SRAM
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x20000000
+      end: 0x20002FFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x2000A000
+      end: 0x3FFFFFFF
+    - name: block 2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40000000
+      end:   0x5FFFFFFF
+    - name: APB
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40000000
+      end:   0x4000A7FF
+    - name: TIM2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40000000
+      end:   0x400003FF
+    - name: TIM3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40000400
+      end:   0x400007FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40000800
+      end:   0x40000FFF
+    - name: TIM6
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40001000
+      end:   0x400013FF
+    - name: TIM7
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40001400
+      end:   0x400017FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40001800
+      end:   0x400023FF
+    - name: LCD
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40002400
+      end:   0x400027FF
+    - name: RTC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40002800
+      end:   0x40002BFF
+    - name: WWDG
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40002C00
+      end:   0x40002FFF
+    - name: IWDG
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40003000
+      end:   0x400033FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40003400
+      end:   0x400037FF
+    - name: SPI2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40003800
+      end:   0x40003BFF
+    - name: SPI3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40003C00
+      end:   0x40003FFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40004000
+      end:   0x400043FF
+    - name: USART2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40004400
+      end:   0x400047FF
+    - name: USART3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40004800
+      end:   0x40004BFF
+    - name: USART4
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40004C00
+      end:   0x40004FFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40005000
+      end:   0x400053FF
+    - name: I2C1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40005400
+      end:   0x400057FF
+    - name: I2C2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40005800
+      end:   0x40005BFF
+    - name: USB
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40005C00
+      end:   0x40005FFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40006000
+      end:   0x40006BFF
+    - name: CRS
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40006C00
+      end:   0x40006FFF
+    - name: PWR
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40007000
+      end:   0x400073FF
+    - name: DAC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40007400
+      end:   0x400077FF
+    - name: OPAMP
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40007800
+      end:   0x40007BFF
+    - name: LPTIM1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40007C00
+      end:   0x40007FFF
+    - name: LPUART1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40008000
+      end:   0x400083FF
+    - name: LPUART2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40008400
+      end:   0x400087FF
+    - name: I2C3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40008800
+      end:   0x40008BFF
+    - name: LPUART3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40008C00
+      end:   0x40008FFF
+    - name: LPTIM3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40009000
+      end:   0x400093FF
+    - name: LPTIM2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40009400
+      end:   0x400097FF
+    - name: USB RAM1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40009800
+      end:   0x40009BFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40009C00
+      end:   0x40009FFF
+    - name: I2C4
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x4000A000
+      end:   0x4000A3FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x4000A400
+      end:   0x4000AFFF
+    - name: TAMP (+BKP registers)
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x4000B000
+      end:   0x4000B3FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x4000B400
+      end:   0x4000FFFF
+    - name: APB
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010000
+      end:   0x40015BFF
+    - name: SYSCFG
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010000
+      end:   0x4001002F
+    - name: VREFBUF
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010030
+      end:   0x4001007F
+    - name: SYSCFG(ITLINE)
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010080
+      end:   0x400101FF
+      note: uses 0x40010000 as base address
+    - name: COMP
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010200
+      end:   0x400103FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40010400
+      end:   0x400123FF
+    - name: ADC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40012400
+      end:   0x400127FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40012800
+      end:   0x40012BFF
+    - name: TIM1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40012C00
+      end:   0x40012FFF
+    - name: SPI1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40013000
+      end:   0x400133FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40013400
+      end:   0x400137FF
+    - name: USART1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40013800
+      end:   0x40013BFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40013C00
+      end:   0x40013FFF
+    - name: TIM15
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40014000
+      end:   0x400143FF
+    - name: TIM16
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40014400
+      end:   0x400147FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40014800
+      end:   0x400157FF
+    - name: DBG
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40015800
+      end:   0x40015BFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40015C00
+      end:   0x4001FFFF
+    - name: AHB
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40020000
+      end:   0x400263FF
+    - name: DMA1
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40020000
+      end:   0x400203FF
+    - name: DMA2
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40020400
+      end:   0x400207FF
+    - name: DMAMUX
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40020800
+      end:   0x40020BFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40020C00
+      end:   0x40020FFF
+    - name: RCC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40021000
+      end:   0x400213FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40021400
+      end:   0x400217FF
+    - name: EXTI
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40021800
+      end:   0x40021BFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40021C00
+      end:   0x40021FFF
+    - name: FLASH
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40022000
+      end:   0x400223FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40022400
+      end:   0x40022FFF
+    - name: CRC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40023000
+      end:   0x400233FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40023400
+      end:   0x40023FFF
+    - name: TSC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40024000
+      end:   0x400243FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40024400
+      end:   0x40024FFF
+    - name: RNG
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40025000
+      end:   0x400253FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40025400
+      end:   0x40025FFF
+    - name: AES
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40026000
+      end:   0x400263FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x40026400
+      end:   0x4FFFFFFF
+    - name: GPIOA
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50000000
+      end:   0x500003FF
+    - name: GPIOB
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50000400
+      end:   0x500007FF
+    - name: GPIOC
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50000800
+      end:   0x50000BFF
+    - name: GPIOD
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50000C00
+      end:   0x50000FFF
+    - name: GPIOE
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50001000
+      end:   0x500013FF
+    - name: GPIOF
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50001400
+      end:   0x500017FF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x50001800
+      end:   0x5FFFFFFF
+    - name: block 3
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x60000000
+      end:   0x7FFFFFFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x60000000
+      end:   0x7FFFFFFF
+    - name: block 4
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x80000000
+      end:   0x9FFFFFFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0x80000000
+      end:   0x9FFFFFFF
+    - name: block 5
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xA0000000
+      end:   0xBFFFFFFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xA0000000
+      end:   0xBFFFFFFF
+    - name: block 6
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xC0000000
+      end:   0xDFFFFFFF
+    - name: reserved
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xC0000000
+      end:   0xDFFFFFFF
+    - name: block 7
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xE0000000
+      end:   0xFFFFFFFF
+    - name: Cortex-M0+ internal peripherals
+      sub-families: [stm32u031, stm32u073, stm32u083]
+      start: 0xE0000000
+      end:   0xE00FFFFF
+peripherals:
+  - gpio:
+    reference:
+      sections: [2.2, 7.4, 7.4.12]
+      tables: [4, 41]
+    registers:
+      - MODER:
+        reference:
+          section: 7.4.1
+        offset: 0x00
+        fields:
+          - name: MODE15
+            msb: 31
+            lsb: 30
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE14
+            msb: 29
+            lsb: 28
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE13
+            msb: 27
+            lsb: 26
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE12
+            msb: 25
+            lsb: 24
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE11
+            msb: 23
+            lsb: 22
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE10
+            msb: 21
+            lsb: 20
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE9
+            msb: 19
+            lsb: 18
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE8
+            msb: 17
+            lsb: 16
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE7
+            msb: 15
+            lsb: 14
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE6
+            msb: 13
+            lsb: 12
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE5
+            msb: 11
+            lsb: 10
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE4
+            msb: 9
+            lsb: 8
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE3
+            msb: 7
+            lsb: 6
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE2
+            msb: 5
+            lsb: 4
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE1
+            msb: 3
+            lsb: 2
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+          - name: MODE0
+            msb: 1
+            lsb: 0
+            width: 2
+            access: rw
+            settings:
+              - 00: input mode
+                01: general purpose output mode
+                10: alternate function mode
+                11: analogue mode
+      - OTYPER:
+        reference:
+          section: 7.4.2
+        offset: 0x04
+        fields:
+          - name: RESERVED
+            msb: 31
+            lsb: 16
+            width: 16
+            access: ro
+            settings: []
+          - name: OT15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+          - name: OT0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: rw
+            settings:
+              - 0: Output push-pull
+                1: Output open-drain
+      - OSPEEDR:
+        reference:
+          section: 7.4.3
+        offset: 0x08
+        fields:
+          - name: OSPEED15
+            msb: 31
+            lsb: 30
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED14
+            msb: 29
+            lsb: 28
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED13
+            msb: 27
+            lsb: 26
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED12
+            msb: 25
+            lsb: 24
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED11
+            msb: 23
+            lsb: 22
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED10
+            msb: 21
+            lsb: 20
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED9
+            msb: 19
+            lsb: 18
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED8
+            msb: 17
+            lsb: 16
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED7
+            msb: 15
+            lsb: 14
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED6
+            msb: 13
+            lsb: 12
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED5
+            msb: 11
+            lsb: 10
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED4
+            msb: 9
+            lsb: 8
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED3
+            msb: 7
+            lsb: 6
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED2
+            msb: 5
+            lsb: 4
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED1
+            msb: 3
+            lsb: 2
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+          - name: OSPEED0
+            msb: 1
+            lsb: 0
+            width: 2
+            access: rw
+            settings:
+              - 00: Low speed
+                01: Medium speed
+                10: High speed
+                11: Very high speed
+      - PUPDR:
+        reference:
+          section: 7.4.4
+        offset: 0x0C
+        fields:
+          - name: PUPDR15
+            msb: 31
+            lsb: 30
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR14
+            msb: 29
+            lsb: 28
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR13
+            msb: 27
+            lsb: 26
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR12
+            msb: 25
+            lsb: 24
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR11
+            msb: 23
+            lsb: 22
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR10
+            msb: 21
+            lsb: 20
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR9
+            msb: 19
+            lsb: 18
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR8
+            msb: 17
+            lsb: 16
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR7
+            msb: 15
+            lsb: 14
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR6
+            msb: 13
+            lsb: 12
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR5
+            msb: 11
+            lsb: 10
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR4
+            msb: 9
+            lsb: 8
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR3
+            msb: 7
+            lsb: 6
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR2
+            msb: 5
+            lsb: 4
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR1
+            msb: 3
+            lsb: 2
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+          - name: PUPDR0
+            msb: 1
+            lsb: 0
+            width: 2
+            access: rw
+            settings:
+              - 00: No pull-up, pull-down
+                01: Pull-up
+                10: Pull-down
+                11: Reserved
+      - IDR:
+        reference:
+          section: 7.4.5
+        offset: 0x10
+        fields:
+          - name: RESERVED
+            msb: 31
+            lsb: 16
+            width: 16
+            access: ro
+            settings: []
+          - name: ID15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+          - name: ID0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: ro
+            settings:
+              - 0: reset
+                1: set
+      - ODR:
+        reference:
+          section: 7.4.6
+        offset: 0x14
+        fields:
+          - name: RESERVED
+            msb: 31
+            lsb: 16
+            width: 16
+            access: ro
+            settings: []
+          - name: OD15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+          - name: OD0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: rw
+            settings:
+              - 0: reset
+                1: set
+      - BSRR:
+        reference:
+          section: 7.4.7
+        offset: 0x18
+        fields:
+          - name: BR15
+            msb: 31
+            lsb: 31
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR14
+            msb: 30
+            lsb: 30
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR13
+            msb: 29
+            lsb: 29
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR12
+            msb: 28
+            lsb: 28
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR11
+            msb: 27
+            lsb: 27
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR10
+            msb: 26
+            lsb: 26
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR9
+            msb: 25
+            lsb: 25
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR8
+            msb: 24
+            lsb: 24
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR7
+            msb: 23
+            lsb: 23
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR6
+            msb: 22
+            lsb: 22
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR5
+            msb: 21
+            lsb: 21
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR4
+            msb: 20
+            lsb: 20
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR3
+            msb: 19
+            lsb: 19
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR2
+            msb: 18
+            lsb: 18
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR1
+            msb: 17
+            lsb: 17
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BR0
+            msb: 16
+            lsb: 16
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Resets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+          - name: BS0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Sets the corresponding ODx bit
+                note: If both BSx and BRx are set, BSx has priority.
+      - LCKR:
+        reference:
+          section: 7.4.8
+        offset: 0x1C
+        sequence:
+          - write:
+            - LCKK: 1
+              LCKR: bits 15:0
+          - write:
+            - LCKK: 0
+              LCKR: bits 15:0
+          - write:
+            - LCKK: 1
+              LCKR: bits 15:0
+          - read:
+            - LCKR: bits 31:0
+          - read:
+            - LCKK: 1
+              note: optional step, but confirms lock is active
+        fields:
+          - name: RESERVED
+            msb: 31
+            lsb: 15
+            width: 15
+            access: ro
+            settings: []
+          - name: LCKK
+            msb: 16
+            lsb: 16
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration lock key not active
+                1: Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or peripheral reset.
+          - name: LCK15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+          - name: LCK0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: rw
+            settings:
+              - 0: Port configuration not locked
+                1: Port configuration locked
+      - AFRL:
+        reference:
+          section: 7.4.9
+        offset: 0x20
+        fields:
+          - name: AFSEL7
+            msb: 31
+            lsb: 28
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL6
+            msb: 27
+            lsb: 24
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL5
+            msb: 23
+            lsb: 20
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL4
+            msb: 19
+            lsb: 16
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL3
+            msb: 15
+            lsb: 12
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL2
+            msb: 11
+            lsb: 8
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL1
+            msb: 7
+            lsb: 4
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL0
+            msb: 3
+            lsb: 0
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+      - AFRH:
+        reference:
+          section: 7.4.10
+        offset: 0x24
+        fields:
+          - name: AFSEL15
+            msb: 31
+            lsb: 28
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL14
+            msb: 27
+            lsb: 24
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL13
+            msb: 23
+            lsb: 20
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL12
+            msb: 19
+            lsb: 16
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL11
+            msb: 15
+            lsb: 12
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL10
+            msb: 11
+            lsb: 8
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL9
+            msb: 7
+            lsb: 4
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+          - name: AFSEL8
+            msb: 3
+            lsb: 0
+            width: 4
+            access: rw
+            settings:
+              - 0000: AF0
+                0001: AF1
+                0010: AF2
+                0011: AF3
+                0100: AF4
+                0101: AF5
+                0110: AF6
+                0111: AF7
+                1000: AF8
+                1001: AF9
+                1010: AF10
+                1011: AF11
+                1100: AF12
+                1101: AF13
+                1110: AF14
+                1111: AF15
+      - BRR:
+        reference:
+          section: 7.4.11
+        offset: 0x28
+        fields:
+          - name: RESERVED
+            msb: 31
+            lsb: 16
+            width: 16
+            access: ro
+            settings: []
+          - name: BR15
+            msb: 15
+            lsb: 15
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR14
+            msb: 14
+            lsb: 14
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR13
+            msb: 13
+            lsb: 13
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR12
+            msb: 12
+            lsb: 12
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR11
+            msb: 11
+            lsb: 11
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR10
+            msb: 10
+            lsb: 10
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR9
+            msb: 9
+            lsb: 9
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR8
+            msb: 8
+            lsb: 8
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR7
+            msb: 7
+            lsb: 7
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR6
+            msb: 6
+            lsb: 6
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR5
+            msb: 5
+            lsb: 5
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR4
+            msb: 4
+            lsb: 4
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR3
+            msb: 3
+            lsb: 3
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR2
+            msb: 2
+            lsb: 2
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR1
+            msb: 1
+            lsb: 1
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit
+          - name: BR0
+            msb: 0
+            lsb: 0
+            width: 1
+            access: wo
+            settings:
+              - 0: No action on the corresponding ODx bit
+                1: Reset the corresponding ODx bit

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1,7 +1,9 @@
 ---
-family: stm32u0
+family:
+  name: stm32u0
   sub-families: [stm32u031, stm32u073, stm32u083]
-architecture: ARM cortex M0+
+architecture:
+  name: ARM cortex M0+
   word-size: 32
 reference:
   source: RM0503
@@ -15,7 +17,7 @@ memory:
     - name: block 0
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x00000000
-      end:   0x1FFFFFFF
+      end: 0x1FFFFFFF
     - name: Main flash memory,  System memory or SRAM. Depends on boot configuration
       sub-families: [stm32u031]
       start: 0x00000000
@@ -71,7 +73,7 @@ memory:
     - name: block 1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x20000000
-      end:   0x3FFFFFFF
+      end: 0x3FFFFFFF
     - name: SRAM
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x20000000
@@ -83,384 +85,384 @@ memory:
     - name: block 2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40000000
-      end:   0x5FFFFFFF
+      end: 0x5FFFFFFF
     - name: APB
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40000000
-      end:   0x4000A7FF
+      end: 0x4000A7FF
     - name: TIM2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40000000
-      end:   0x400003FF
+      end: 0x400003FF
     - name: TIM3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40000400
-      end:   0x400007FF
+      end: 0x400007FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40000800
-      end:   0x40000FFF
+      end: 0x40000FFF
     - name: TIM6
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40001000
-      end:   0x400013FF
+      end: 0x400013FF
     - name: TIM7
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40001400
-      end:   0x400017FF
+      end: 0x400017FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40001800
-      end:   0x400023FF
+      end: 0x400023FF
     - name: LCD
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40002400
-      end:   0x400027FF
+      end: 0x400027FF
     - name: RTC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40002800
-      end:   0x40002BFF
+      end: 0x40002BFF
     - name: WWDG
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40002C00
-      end:   0x40002FFF
+      end: 0x40002FFF
     - name: IWDG
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40003000
-      end:   0x400033FF
+      end: 0x400033FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40003400
-      end:   0x400037FF
+      end: 0x400037FF
     - name: SPI2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40003800
-      end:   0x40003BFF
+      end: 0x40003BFF
     - name: SPI3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40003C00
-      end:   0x40003FFF
+      end: 0x40003FFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40004000
-      end:   0x400043FF
+      end: 0x400043FF
     - name: USART2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40004400
-      end:   0x400047FF
+      end: 0x400047FF
     - name: USART3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40004800
-      end:   0x40004BFF
+      end: 0x40004BFF
     - name: USART4
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40004C00
-      end:   0x40004FFF
+      end: 0x40004FFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40005000
-      end:   0x400053FF
+      end: 0x400053FF
     - name: I2C1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40005400
-      end:   0x400057FF
+      end: 0x400057FF
     - name: I2C2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40005800
-      end:   0x40005BFF
+      end: 0x40005BFF
     - name: USB
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40005C00
-      end:   0x40005FFF
+      end: 0x40005FFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40006000
-      end:   0x40006BFF
+      end: 0x40006BFF
     - name: CRS
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40006C00
-      end:   0x40006FFF
+      end: 0x40006FFF
     - name: PWR
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40007000
-      end:   0x400073FF
+      end: 0x400073FF
     - name: DAC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40007400
-      end:   0x400077FF
+      end: 0x400077FF
     - name: OPAMP
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40007800
-      end:   0x40007BFF
+      end: 0x40007BFF
     - name: LPTIM1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40007C00
-      end:   0x40007FFF
+      end: 0x40007FFF
     - name: LPUART1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40008000
-      end:   0x400083FF
+      end: 0x400083FF
     - name: LPUART2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40008400
-      end:   0x400087FF
+      end: 0x400087FF
     - name: I2C3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40008800
-      end:   0x40008BFF
+      end: 0x40008BFF
     - name: LPUART3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40008C00
-      end:   0x40008FFF
+      end: 0x40008FFF
     - name: LPTIM3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40009000
-      end:   0x400093FF
+      end: 0x400093FF
     - name: LPTIM2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40009400
-      end:   0x400097FF
+      end: 0x400097FF
     - name: USB RAM1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40009800
-      end:   0x40009BFF
+      end: 0x40009BFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40009C00
-      end:   0x40009FFF
+      end: 0x40009FFF
     - name: I2C4
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x4000A000
-      end:   0x4000A3FF
+      end: 0x4000A3FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x4000A400
-      end:   0x4000AFFF
+      end: 0x4000AFFF
     - name: TAMP (+BKP registers)
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x4000B000
-      end:   0x4000B3FF
+      end: 0x4000B3FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x4000B400
-      end:   0x4000FFFF
+      end: 0x4000FFFF
     - name: APB
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010000
-      end:   0x40015BFF
+      end: 0x40015BFF
     - name: SYSCFG
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010000
-      end:   0x4001002F
+      end: 0x4001002F
     - name: VREFBUF
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010030
-      end:   0x4001007F
+      end: 0x4001007F
     - name: SYSCFG(ITLINE)
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010080
-      end:   0x400101FF
+      end: 0x400101FF
       note: uses 0x40010000 as base address
     - name: COMP
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010200
-      end:   0x400103FF
+      end: 0x400103FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010400
-      end:   0x400123FF
+      end: 0x400123FF
     - name: ADC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40012400
-      end:   0x400127FF
+      end: 0x400127FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40012800
-      end:   0x40012BFF
+      end: 0x40012BFF
     - name: TIM1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40012C00
-      end:   0x40012FFF
+      end: 0x40012FFF
     - name: SPI1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40013000
-      end:   0x400133FF
+      end: 0x400133FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40013400
-      end:   0x400137FF
+      end: 0x400137FF
     - name: USART1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40013800
-      end:   0x40013BFF
+      end: 0x40013BFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40013C00
-      end:   0x40013FFF
+      end: 0x40013FFF
     - name: TIM15
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40014000
-      end:   0x400143FF
+      end: 0x400143FF
     - name: TIM16
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40014400
-      end:   0x400147FF
+      end: 0x400147FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40014800
-      end:   0x400157FF
+      end: 0x400157FF
     - name: DBG
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40015800
-      end:   0x40015BFF
+      end: 0x40015BFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40015C00
-      end:   0x4001FFFF
+      end: 0x4001FFFF
     - name: AHB
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40020000
-      end:   0x400263FF
+      end: 0x400263FF
     - name: DMA1
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40020000
-      end:   0x400203FF
+      end: 0x400203FF
     - name: DMA2
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40020400
-      end:   0x400207FF
+      end: 0x400207FF
     - name: DMAMUX
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40020800
-      end:   0x40020BFF
+      end: 0x40020BFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40020C00
-      end:   0x40020FFF
+      end: 0x40020FFF
     - name: RCC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40021000
-      end:   0x400213FF
+      end: 0x400213FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40021400
-      end:   0x400217FF
+      end: 0x400217FF
     - name: EXTI
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40021800
-      end:   0x40021BFF
+      end: 0x40021BFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40021C00
-      end:   0x40021FFF
+      end: 0x40021FFF
     - name: FLASH
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40022000
-      end:   0x400223FF
+      end: 0x400223FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40022400
-      end:   0x40022FFF
+      end: 0x40022FFF
     - name: CRC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40023000
-      end:   0x400233FF
+      end: 0x400233FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40023400
-      end:   0x40023FFF
+      end: 0x40023FFF
     - name: TSC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40024000
-      end:   0x400243FF
+      end: 0x400243FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40024400
-      end:   0x40024FFF
+      end: 0x40024FFF
     - name: RNG
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40025000
-      end:   0x400253FF
+      end: 0x400253FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40025400
-      end:   0x40025FFF
+      end: 0x40025FFF
     - name: AES
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40026000
-      end:   0x400263FF
+      end: 0x400263FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40026400
-      end:   0x4FFFFFFF
+      end: 0x4FFFFFFF
     - name: GPIOA
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50000000
-      end:   0x500003FF
+      end: 0x500003FF
     - name: GPIOB
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50000400
-      end:   0x500007FF
+      end: 0x500007FF
     - name: GPIOC
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50000800
-      end:   0x50000BFF
+      end: 0x50000BFF
     - name: GPIOD
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50000C00
-      end:   0x50000FFF
+      end: 0x50000FFF
     - name: GPIOE
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50001000
-      end:   0x500013FF
+      end: 0x500013FF
     - name: GPIOF
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50001400
-      end:   0x500017FF
+      end: 0x500017FF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x50001800
-      end:   0x5FFFFFFF
+      end: 0x5FFFFFFF
     - name: block 3
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x60000000
-      end:   0x7FFFFFFF
+      end: 0x7FFFFFFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x60000000
-      end:   0x7FFFFFFF
+      end: 0x7FFFFFFF
     - name: block 4
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x80000000
-      end:   0x9FFFFFFF
+      end: 0x9FFFFFFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x80000000
-      end:   0x9FFFFFFF
+      end: 0x9FFFFFFF
     - name: block 5
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xA0000000
-      end:   0xBFFFFFFF
+      end: 0xBFFFFFFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xA0000000
-      end:   0xBFFFFFFF
+      end: 0xBFFFFFFF
     - name: block 6
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xC0000000
-      end:   0xDFFFFFFF
+      end: 0xDFFFFFFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xC0000000
-      end:   0xDFFFFFFF
+      end: 0xDFFFFFFF
     - name: block 7
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xE0000000
-      end:   0xFFFFFFFF
+      end: 0xFFFFFFFF
     - name: Cortex-M0+ internal peripherals
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xE0000000
-      end:   0xE00FFFFF
+      end: 0xE00FFFFF
 peripherals:
   - gpio:
     reference:
@@ -1686,19 +1688,19 @@ peripherals:
         offset: 0x1C
         sequence:
           - write:
-            - LCKK: 1
-              LCKR: bits 15:0
+              - LCKK: 1
+                LCKR: bits 15:0
           - write:
-            - LCKK: 0
-              LCKR: bits 15:0
+              - LCKK: 0
+                LCKR: bits 15:0
           - write:
-            - LCKK: 1
-              LCKR: bits 15:0
+              - LCKK: 1
+                LCKR: bits 15:0
           - read:
-            - LCKR: bits 31:0
+              - LCKR: bits 31:0
           - read:
-            - LCKK: 1
-              note: optional step, but confirms lock is active
+              - LCKK: 1
+                note: optional step, but confirms lock is active
         fields:
           - name: RESERVED
             msb: 31
@@ -1713,7 +1715,9 @@ peripherals:
             access: rw
             settings:
               - 0: Port configuration lock key not active
-                1: Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or peripheral reset.
+                1: >-
+                  Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or
+                  peripheral reset.
           - name: LCK15
             msb: 15
             lsb: 15

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -653,14 +653,6 @@ peripherals:
             settings:
               - 0: Output push-pull
                 1: Output open-drain
-          - name: OT15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
           - name: OT14
             msb: 14
             lsb: 14

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -7,6 +7,7 @@ family:
 architecture:
   name: ARM Cortex-M0+
   word-size: 32
+arch-ref: cortex-m0plus
 reference:
   source: RM0503
   revision: 4
@@ -470,12 +471,12 @@ memory:
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xE0000000
       end: 0xFFFFFFFF
-    - name: Cortex-M0+ internal peripherals
-      sub-families: [stm32u031, stm32u073, stm32u083]
-      start: 0xE0000000
-      end: 0xE00FFFFF
+      # Cortex-M0+ internal peripherals (0xE0000000–0xE00FFFFF) are defined in
+      # docs/specs/common/arch/cortex-m0plus.yml and are not repeated here.
 definitions:
   settings:
+    # Architecture-generic: canonical definition lives in docs/specs/common/arch/cortex-m0plus.yml.
+    # Repeated here because YAML anchors cannot span files.
     gpio-mode: &gpio-mode
       "00": input mode
       "01": general purpose output mode
@@ -494,6 +495,8 @@ definitions:
       "01": Pull-up
       "10": Pull-down
       "11": Reserved
+    # Architecture-generic: canonical definition lives in docs/specs/common/arch/cortex-m0plus.yml.
+    # Repeated here because YAML anchors cannot span files.
     bit-value: &bit-value
       "0": reset
       "1": set

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -87,9 +87,9 @@ memory:
       end: 0x20009FFF
       verified: false
       note: >-
-        Inferred gap: stm32u031 SRAM ends at 0x20002FFF and the next documented region starts
-        at 0x2000A000. This reserved entry fills the intervening address space but has not yet
-        been confirmed against the reference manual (RM0503). Mark verified: true once checked.
+        Table 2 of RM0503 does not document this address range: stm32u031 SRAM ends at
+        0x20002FFF and the next listed region starts at 0x2000A000, leaving this gap unlabelled.
+        Assumed reserved until a citable reference is located.
     - name: SRAM
       sub-families: [stm32u073, stm32u083]
       start: 0x20000000

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1,5 +1,5 @@
 ---
-spec-version: "1.0"
+spec-version: "1.0.0"
 vendor: STMicroelectronics
 family:
   name: stm32u0

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -472,6 +472,58 @@ memory:
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0xE0000000
       end: 0xE00FFFFF
+definitions:
+  settings:
+    gpio-mode: &gpio-mode
+      "00": input mode
+      "01": general purpose output mode
+      "10": alternate function mode
+      "11": analogue mode
+    output-type: &output-type
+      "0": Output push-pull
+      "1": Output open-drain
+    ospeed: &ospeed
+      "00": Low speed
+      "01": Medium speed
+      "10": High speed
+      "11": Very high speed
+    pupdr: &pupdr
+      "00": No pull-up, pull-down
+      "01": Pull-up
+      "10": Pull-down
+      "11": Reserved
+    bit-value: &bit-value
+      "0": reset
+      "1": set
+    bsrr-br: &bsrr-br
+      "0": No action on the corresponding ODx bit
+      "1": Resets the corresponding ODx bit
+    bsrr-bs: &bsrr-bs
+      "0": No action on the corresponding ODx bit
+      "1": Sets the corresponding ODx bit
+    port-lock: &port-lock
+      "0": Port configuration not locked
+      "1": Port configuration locked
+    afsel: &afsel
+      "0000": AF0
+      "0001": AF1
+      "0010": AF2
+      "0011": AF3
+      "0100": AF4
+      "0101": AF5
+      "0110": AF6
+      "0111": AF7
+      "1000": AF8
+      "1001": AF9
+      "1010": AF10
+      "1011": AF11
+      "1100": AF12
+      "1101": AF13
+      "1110": AF14
+      "1111": AF15
+    brr: &brr
+      "0": No action on the corresponding ODx bit
+      "1": Reset the corresponding ODx bit
 peripherals:
   - gpio:
       reference:
@@ -488,161 +540,97 @@ peripherals:
                 lsb: 30
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE14
                 msb: 29
                 lsb: 28
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE13
                 msb: 27
                 lsb: 26
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE12
                 msb: 25
                 lsb: 24
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE11
                 msb: 23
                 lsb: 22
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE10
                 msb: 21
                 lsb: 20
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE9
                 msb: 19
                 lsb: 18
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE8
                 msb: 17
                 lsb: 16
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE7
                 msb: 15
                 lsb: 14
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE6
                 msb: 13
                 lsb: 12
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE5
                 msb: 11
                 lsb: 10
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE4
                 msb: 9
                 lsb: 8
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE3
                 msb: 7
                 lsb: 6
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE2
                 msb: 5
                 lsb: 4
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE1
                 msb: 3
                 lsb: 2
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
               - name: MODE0
                 msb: 1
                 lsb: 0
                 width: 2
                 access: rw
-                settings:
-                  - "00": input mode
-                    "01": general purpose output mode
-                    "10": alternate function mode
-                    "11": analogue mode
+                settings: *gpio-mode
         - OTYPER:
             reference:
               section: 7.4.2
@@ -653,135 +641,103 @@ peripherals:
                 lsb: 16
                 width: 16
                 access: ro
-                settings: []
+                settings: ~
               - name: OT15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
               - name: OT0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: rw
-                settings:
-                  - "0": Output push-pull
-                    "1": Output open-drain
+                settings: *output-type
         - OSPEEDR:
             reference:
               section: 7.4.3
@@ -792,161 +748,97 @@ peripherals:
                 lsb: 30
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED14
                 msb: 29
                 lsb: 28
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED13
                 msb: 27
                 lsb: 26
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED12
                 msb: 25
                 lsb: 24
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED11
                 msb: 23
                 lsb: 22
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED10
                 msb: 21
                 lsb: 20
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED9
                 msb: 19
                 lsb: 18
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED8
                 msb: 17
                 lsb: 16
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED7
                 msb: 15
                 lsb: 14
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED6
                 msb: 13
                 lsb: 12
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED5
                 msb: 11
                 lsb: 10
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED4
                 msb: 9
                 lsb: 8
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED3
                 msb: 7
                 lsb: 6
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED2
                 msb: 5
                 lsb: 4
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED1
                 msb: 3
                 lsb: 2
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
               - name: OSPEED0
                 msb: 1
                 lsb: 0
                 width: 2
                 access: rw
-                settings:
-                  - "00": Low speed
-                    "01": Medium speed
-                    "10": High speed
-                    "11": Very high speed
+                settings: *ospeed
         - PUPDR:
             reference:
               section: 7.4.4
@@ -957,161 +849,97 @@ peripherals:
                 lsb: 30
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR14
                 msb: 29
                 lsb: 28
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR13
                 msb: 27
                 lsb: 26
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR12
                 msb: 25
                 lsb: 24
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR11
                 msb: 23
                 lsb: 22
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR10
                 msb: 21
                 lsb: 20
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR9
                 msb: 19
                 lsb: 18
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR8
                 msb: 17
                 lsb: 16
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR7
                 msb: 15
                 lsb: 14
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR6
                 msb: 13
                 lsb: 12
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR5
                 msb: 11
                 lsb: 10
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR4
                 msb: 9
                 lsb: 8
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR3
                 msb: 7
                 lsb: 6
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR2
                 msb: 5
                 lsb: 4
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR1
                 msb: 3
                 lsb: 2
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
               - name: PUPDR0
                 msb: 1
                 lsb: 0
                 width: 2
                 access: rw
-                settings:
-                  - "00": No pull-up, pull-down
-                    "01": Pull-up
-                    "10": Pull-down
-                    "11": Reserved
+                settings: *pupdr
         - IDR:
             reference:
               section: 7.4.5
@@ -1122,135 +950,103 @@ peripherals:
                 lsb: 16
                 width: 16
                 access: ro
-                settings: []
+                settings: ~
               - name: ID15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: ID0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: ro
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
         - ODR:
             reference:
               section: 7.4.6
@@ -1261,135 +1057,103 @@ peripherals:
                 lsb: 16
                 width: 16
                 access: ro
-                settings: []
+                settings: ~
               - name: OD15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
               - name: OD0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: rw
-                settings:
-                  - "0": reset
-                    "1": set
+                settings: *bit-value
         - BSRR:
             reference:
               section: 7.4.7
@@ -1400,289 +1164,225 @@ peripherals:
                 lsb: 31
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR14
                 msb: 30
                 lsb: 30
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR13
                 msb: 29
                 lsb: 29
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR12
                 msb: 28
                 lsb: 28
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR11
                 msb: 27
                 lsb: 27
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR10
                 msb: 26
                 lsb: 26
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR9
                 msb: 25
                 lsb: 25
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR8
                 msb: 24
                 lsb: 24
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR7
                 msb: 23
                 lsb: 23
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR6
                 msb: 22
                 lsb: 22
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR5
                 msb: 21
                 lsb: 21
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR4
                 msb: 20
                 lsb: 20
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR3
                 msb: 19
                 lsb: 19
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR2
                 msb: 18
                 lsb: 18
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR1
                 msb: 17
                 lsb: 17
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BR0
                 msb: 16
                 lsb: 16
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Resets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-br
               - name: BS15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
               - name: BS0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Sets the corresponding ODx bit
-                    note: If both BSx and BRx are set, BSx has priority.
+                note: If both BSx and BRx are set, BSx has priority.
+                settings: *bsrr-bs
         - LCKR:
             reference:
               section: 7.4.8
@@ -1705,148 +1405,116 @@ peripherals:
             fields:
               - name: RESERVED
                 msb: 31
-                lsb: 15
+                lsb: 17
                 width: 15
                 access: ro
-                settings: []
+                settings: ~
               - name: LCKK
                 msb: 16
                 lsb: 16
                 width: 1
                 access: rw
                 settings:
-                  - "0": Port configuration lock key not active
-                    "1": >-
-                      Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or
-                      peripheral reset.
+                  "0": Port configuration lock key not active
+                  "1": >-
+                    Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or
+                    peripheral reset.
               - name: LCK15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
               - name: LCK0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: rw
-                settings:
-                  - "0": Port configuration not locked
-                    "1": Port configuration locked
+                settings: *port-lock
         - AFRL:
             reference:
               section: 7.4.9
@@ -1857,177 +1525,49 @@ peripherals:
                 lsb: 28
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL6
                 msb: 27
                 lsb: 24
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL5
                 msb: 23
                 lsb: 20
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL4
                 msb: 19
                 lsb: 16
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL3
                 msb: 15
                 lsb: 12
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL2
                 msb: 11
                 lsb: 8
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL1
                 msb: 7
                 lsb: 4
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL0
                 msb: 3
                 lsb: 0
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
         - AFRH:
             reference:
               section: 7.4.10
@@ -2038,177 +1578,49 @@ peripherals:
                 lsb: 28
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL14
                 msb: 27
                 lsb: 24
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL13
                 msb: 23
                 lsb: 20
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL12
                 msb: 19
                 lsb: 16
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL11
                 msb: 15
                 lsb: 12
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL10
                 msb: 11
                 lsb: 8
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL9
                 msb: 7
                 lsb: 4
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
               - name: AFSEL8
                 msb: 3
                 lsb: 0
                 width: 4
                 access: rw
-                settings:
-                  - "0000": AF0
-                    "0001": AF1
-                    "0010": AF2
-                    "0011": AF3
-                    "0100": AF4
-                    "0101": AF5
-                    "0110": AF6
-                    "0111": AF7
-                    "1000": AF8
-                    "1001": AF9
-                    "1010": AF10
-                    "1011": AF11
-                    "1100": AF12
-                    "1101": AF13
-                    "1110": AF14
-                    "1111": AF15
+                settings: *afsel
         - BRR:
             reference:
               section: 7.4.11
@@ -2219,132 +1631,100 @@ peripherals:
                 lsb: 16
                 width: 16
                 access: ro
-                settings: []
+                settings: ~
               - name: BR15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr
               - name: BR0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: wo
-                settings:
-                  - "0": No action on the corresponding ODx bit
-                    "1": Reset the corresponding ODx bit
+                settings: *brr

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1,4 +1,5 @@
 ---
+vendor: STMicroelectronics
 family:
   name: stm32u0
   sub-families: [stm32u031, stm32u073, stm32u083]

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -3,7 +3,7 @@ family:
   name: stm32u0
   sub-families: [stm32u031, stm32u073, stm32u083]
 architecture:
-  name: ARM cortex M0+
+  name: ARM Cortex-M0+
   word-size: 32
 reference:
   source: RM0503
@@ -18,7 +18,7 @@ memory:
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x00000000
       end: 0x1FFFFFFF
-    - name: Main flash memory,  System memory or SRAM. Depends on boot configuration
+    - name: Main flash memory, System memory or SRAM. Depends on boot configuration
       sub-families: [stm32u031]
       start: 0x00000000
       end: 0x0001FFFF
@@ -477,1874 +477,1874 @@ peripherals:
       reference:
         sections: [2.2, 7.4, 7.4.12]
         tables: [4, 41]
-    registers:
-      - MODER:
-        reference:
-          section: 7.4.1
-        offset: 0x00
-        fields:
-          - name: MODE15
-            msb: 31
-            lsb: 30
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE14
-            msb: 29
-            lsb: 28
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE13
-            msb: 27
-            lsb: 26
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE12
-            msb: 25
-            lsb: 24
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE11
-            msb: 23
-            lsb: 22
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE10
-            msb: 21
-            lsb: 20
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE9
-            msb: 19
-            lsb: 18
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE8
-            msb: 17
-            lsb: 16
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE7
-            msb: 15
-            lsb: 14
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE6
-            msb: 13
-            lsb: 12
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE5
-            msb: 11
-            lsb: 10
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE4
-            msb: 9
-            lsb: 8
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE3
-            msb: 7
-            lsb: 6
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE2
-            msb: 5
-            lsb: 4
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE1
-            msb: 3
-            lsb: 2
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-          - name: MODE0
-            msb: 1
-            lsb: 0
-            width: 2
-            access: rw
-            settings:
-              - 00: input mode
-                01: general purpose output mode
-                10: alternate function mode
-                11: analogue mode
-      - OTYPER:
-        reference:
-          section: 7.4.2
-        offset: 0x04
-        fields:
-          - name: RESERVED
-            msb: 31
-            lsb: 16
-            width: 16
-            access: ro
-            settings: []
-          - name: OT15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-          - name: OT0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: rw
-            settings:
-              - 0: Output push-pull
-                1: Output open-drain
-      - OSPEEDR:
-        reference:
-          section: 7.4.3
-        offset: 0x08
-        fields:
-          - name: OSPEED15
-            msb: 31
-            lsb: 30
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED14
-            msb: 29
-            lsb: 28
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED13
-            msb: 27
-            lsb: 26
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED12
-            msb: 25
-            lsb: 24
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED11
-            msb: 23
-            lsb: 22
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED10
-            msb: 21
-            lsb: 20
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED9
-            msb: 19
-            lsb: 18
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED8
-            msb: 17
-            lsb: 16
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED7
-            msb: 15
-            lsb: 14
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED6
-            msb: 13
-            lsb: 12
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED5
-            msb: 11
-            lsb: 10
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED4
-            msb: 9
-            lsb: 8
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED3
-            msb: 7
-            lsb: 6
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED2
-            msb: 5
-            lsb: 4
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED1
-            msb: 3
-            lsb: 2
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-          - name: OSPEED0
-            msb: 1
-            lsb: 0
-            width: 2
-            access: rw
-            settings:
-              - 00: Low speed
-                01: Medium speed
-                10: High speed
-                11: Very high speed
-      - PUPDR:
-        reference:
-          section: 7.4.4
-        offset: 0x0C
-        fields:
-          - name: PUPDR15
-            msb: 31
-            lsb: 30
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR14
-            msb: 29
-            lsb: 28
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR13
-            msb: 27
-            lsb: 26
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR12
-            msb: 25
-            lsb: 24
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR11
-            msb: 23
-            lsb: 22
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR10
-            msb: 21
-            lsb: 20
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR9
-            msb: 19
-            lsb: 18
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR8
-            msb: 17
-            lsb: 16
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR7
-            msb: 15
-            lsb: 14
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR6
-            msb: 13
-            lsb: 12
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR5
-            msb: 11
-            lsb: 10
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR4
-            msb: 9
-            lsb: 8
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR3
-            msb: 7
-            lsb: 6
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR2
-            msb: 5
-            lsb: 4
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR1
-            msb: 3
-            lsb: 2
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-          - name: PUPDR0
-            msb: 1
-            lsb: 0
-            width: 2
-            access: rw
-            settings:
-              - 00: No pull-up, pull-down
-                01: Pull-up
-                10: Pull-down
-                11: Reserved
-      - IDR:
-        reference:
-          section: 7.4.5
-        offset: 0x10
-        fields:
-          - name: RESERVED
-            msb: 31
-            lsb: 16
-            width: 16
-            access: ro
-            settings: []
-          - name: ID15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-          - name: ID0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: ro
-            settings:
-              - 0: reset
-                1: set
-      - ODR:
-        reference:
-          section: 7.4.6
-        offset: 0x14
-        fields:
-          - name: RESERVED
-            msb: 31
-            lsb: 16
-            width: 16
-            access: ro
-            settings: []
-          - name: OD15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-          - name: OD0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: rw
-            settings:
-              - 0: reset
-                1: set
-      - BSRR:
-        reference:
-          section: 7.4.7
-        offset: 0x18
-        fields:
-          - name: BR15
-            msb: 31
-            lsb: 31
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR14
-            msb: 30
-            lsb: 30
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR13
-            msb: 29
-            lsb: 29
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR12
-            msb: 28
-            lsb: 28
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR11
-            msb: 27
-            lsb: 27
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR10
-            msb: 26
-            lsb: 26
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR9
-            msb: 25
-            lsb: 25
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR8
-            msb: 24
-            lsb: 24
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR7
-            msb: 23
-            lsb: 23
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR6
-            msb: 22
-            lsb: 22
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR5
-            msb: 21
-            lsb: 21
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR4
-            msb: 20
-            lsb: 20
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR3
-            msb: 19
-            lsb: 19
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR2
-            msb: 18
-            lsb: 18
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR1
-            msb: 17
-            lsb: 17
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BR0
-            msb: 16
-            lsb: 16
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Resets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-          - name: BS0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Sets the corresponding ODx bit
-                note: If both BSx and BRx are set, BSx has priority.
-      - LCKR:
-        reference:
-          section: 7.4.8
-        offset: 0x1C
-        sequence:
-          - write:
-              - LCKK: 1
-                LCKR: bits 15:0
-          - write:
-              - LCKK: 0
-                LCKR: bits 15:0
-          - write:
-              - LCKK: 1
-                LCKR: bits 15:0
-          - read:
-              - LCKR: bits 31:0
-          - read:
-              - LCKK: 1
-                note: optional step, but confirms lock is active
-        fields:
-          - name: RESERVED
-            msb: 31
-            lsb: 15
-            width: 15
-            access: ro
-            settings: []
-          - name: LCKK
-            msb: 16
-            lsb: 16
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration lock key not active
-                1: >-
-                  Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or
-                  peripheral reset.
-          - name: LCK15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-          - name: LCK0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: rw
-            settings:
-              - 0: Port configuration not locked
-                1: Port configuration locked
-      - AFRL:
-        reference:
-          section: 7.4.9
-        offset: 0x20
-        fields:
-          - name: AFSEL7
-            msb: 31
-            lsb: 28
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL6
-            msb: 27
-            lsb: 24
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL5
-            msb: 23
-            lsb: 20
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL4
-            msb: 19
-            lsb: 16
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL3
-            msb: 15
-            lsb: 12
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL2
-            msb: 11
-            lsb: 8
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL1
-            msb: 7
-            lsb: 4
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL0
-            msb: 3
-            lsb: 0
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-      - AFRH:
-        reference:
-          section: 7.4.10
-        offset: 0x24
-        fields:
-          - name: AFSEL15
-            msb: 31
-            lsb: 28
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL14
-            msb: 27
-            lsb: 24
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL13
-            msb: 23
-            lsb: 20
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL12
-            msb: 19
-            lsb: 16
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL11
-            msb: 15
-            lsb: 12
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL10
-            msb: 11
-            lsb: 8
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL9
-            msb: 7
-            lsb: 4
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-          - name: AFSEL8
-            msb: 3
-            lsb: 0
-            width: 4
-            access: rw
-            settings:
-              - 0000: AF0
-                0001: AF1
-                0010: AF2
-                0011: AF3
-                0100: AF4
-                0101: AF5
-                0110: AF6
-                0111: AF7
-                1000: AF8
-                1001: AF9
-                1010: AF10
-                1011: AF11
-                1100: AF12
-                1101: AF13
-                1110: AF14
-                1111: AF15
-      - BRR:
-        reference:
-          section: 7.4.11
-        offset: 0x28
-        fields:
-          - name: RESERVED
-            msb: 31
-            lsb: 16
-            width: 16
-            access: ro
-            settings: []
-          - name: BR15
-            msb: 15
-            lsb: 15
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR14
-            msb: 14
-            lsb: 14
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR13
-            msb: 13
-            lsb: 13
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR12
-            msb: 12
-            lsb: 12
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR11
-            msb: 11
-            lsb: 11
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR10
-            msb: 10
-            lsb: 10
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR9
-            msb: 9
-            lsb: 9
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR8
-            msb: 8
-            lsb: 8
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR7
-            msb: 7
-            lsb: 7
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR6
-            msb: 6
-            lsb: 6
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR5
-            msb: 5
-            lsb: 5
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR4
-            msb: 4
-            lsb: 4
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR3
-            msb: 3
-            lsb: 3
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR2
-            msb: 2
-            lsb: 2
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR1
-            msb: 1
-            lsb: 1
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
-          - name: BR0
-            msb: 0
-            lsb: 0
-            width: 1
-            access: wo
-            settings:
-              - 0: No action on the corresponding ODx bit
-                1: Reset the corresponding ODx bit
+      registers:
+        - MODER:
+            reference:
+              section: 7.4.1
+            offset: 0x00
+            fields:
+              - name: MODE15
+                msb: 31
+                lsb: 30
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE14
+                msb: 29
+                lsb: 28
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE13
+                msb: 27
+                lsb: 26
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE12
+                msb: 25
+                lsb: 24
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE11
+                msb: 23
+                lsb: 22
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE10
+                msb: 21
+                lsb: 20
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE9
+                msb: 19
+                lsb: 18
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE8
+                msb: 17
+                lsb: 16
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE7
+                msb: 15
+                lsb: 14
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE6
+                msb: 13
+                lsb: 12
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE5
+                msb: 11
+                lsb: 10
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE4
+                msb: 9
+                lsb: 8
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE3
+                msb: 7
+                lsb: 6
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE2
+                msb: 5
+                lsb: 4
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE1
+                msb: 3
+                lsb: 2
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+              - name: MODE0
+                msb: 1
+                lsb: 0
+                width: 2
+                access: rw
+                settings:
+                  - "00": input mode
+                    "01": general purpose output mode
+                    "10": alternate function mode
+                    "11": analogue mode
+        - OTYPER:
+            reference:
+              section: 7.4.2
+            offset: 0x04
+            fields:
+              - name: RESERVED
+                msb: 31
+                lsb: 16
+                width: 16
+                access: ro
+                settings: []
+              - name: OT15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+              - name: OT0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: rw
+                settings:
+                  - "0": Output push-pull
+                    "1": Output open-drain
+        - OSPEEDR:
+            reference:
+              section: 7.4.3
+            offset: 0x08
+            fields:
+              - name: OSPEED15
+                msb: 31
+                lsb: 30
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED14
+                msb: 29
+                lsb: 28
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED13
+                msb: 27
+                lsb: 26
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED12
+                msb: 25
+                lsb: 24
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED11
+                msb: 23
+                lsb: 22
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED10
+                msb: 21
+                lsb: 20
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED9
+                msb: 19
+                lsb: 18
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED8
+                msb: 17
+                lsb: 16
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED7
+                msb: 15
+                lsb: 14
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED6
+                msb: 13
+                lsb: 12
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED5
+                msb: 11
+                lsb: 10
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED4
+                msb: 9
+                lsb: 8
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED3
+                msb: 7
+                lsb: 6
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED2
+                msb: 5
+                lsb: 4
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED1
+                msb: 3
+                lsb: 2
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+              - name: OSPEED0
+                msb: 1
+                lsb: 0
+                width: 2
+                access: rw
+                settings:
+                  - "00": Low speed
+                    "01": Medium speed
+                    "10": High speed
+                    "11": Very high speed
+        - PUPDR:
+            reference:
+              section: 7.4.4
+            offset: 0x0C
+            fields:
+              - name: PUPDR15
+                msb: 31
+                lsb: 30
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR14
+                msb: 29
+                lsb: 28
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR13
+                msb: 27
+                lsb: 26
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR12
+                msb: 25
+                lsb: 24
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR11
+                msb: 23
+                lsb: 22
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR10
+                msb: 21
+                lsb: 20
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR9
+                msb: 19
+                lsb: 18
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR8
+                msb: 17
+                lsb: 16
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR7
+                msb: 15
+                lsb: 14
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR6
+                msb: 13
+                lsb: 12
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR5
+                msb: 11
+                lsb: 10
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR4
+                msb: 9
+                lsb: 8
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR3
+                msb: 7
+                lsb: 6
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR2
+                msb: 5
+                lsb: 4
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR1
+                msb: 3
+                lsb: 2
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+              - name: PUPDR0
+                msb: 1
+                lsb: 0
+                width: 2
+                access: rw
+                settings:
+                  - "00": No pull-up, pull-down
+                    "01": Pull-up
+                    "10": Pull-down
+                    "11": Reserved
+        - IDR:
+            reference:
+              section: 7.4.5
+            offset: 0x10
+            fields:
+              - name: RESERVED
+                msb: 31
+                lsb: 16
+                width: 16
+                access: ro
+                settings: []
+              - name: ID15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: ID0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: ro
+                settings:
+                  - "0": reset
+                    "1": set
+        - ODR:
+            reference:
+              section: 7.4.6
+            offset: 0x14
+            fields:
+              - name: RESERVED
+                msb: 31
+                lsb: 16
+                width: 16
+                access: ro
+                settings: []
+              - name: OD15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+              - name: OD0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: rw
+                settings:
+                  - "0": reset
+                    "1": set
+        - BSRR:
+            reference:
+              section: 7.4.7
+            offset: 0x18
+            fields:
+              - name: BR15
+                msb: 31
+                lsb: 31
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR14
+                msb: 30
+                lsb: 30
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR13
+                msb: 29
+                lsb: 29
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR12
+                msb: 28
+                lsb: 28
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR11
+                msb: 27
+                lsb: 27
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR10
+                msb: 26
+                lsb: 26
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR9
+                msb: 25
+                lsb: 25
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR8
+                msb: 24
+                lsb: 24
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR7
+                msb: 23
+                lsb: 23
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR6
+                msb: 22
+                lsb: 22
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR5
+                msb: 21
+                lsb: 21
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR4
+                msb: 20
+                lsb: 20
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR3
+                msb: 19
+                lsb: 19
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR2
+                msb: 18
+                lsb: 18
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR1
+                msb: 17
+                lsb: 17
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BR0
+                msb: 16
+                lsb: 16
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Resets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+              - name: BS0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Sets the corresponding ODx bit
+                    note: If both BSx and BRx are set, BSx has priority.
+        - LCKR:
+            reference:
+              section: 7.4.8
+            offset: 0x1C
+            sequence:
+              - write:
+                  - LCKK: 1
+                    LCKR: bits 15:0
+              - write:
+                  - LCKK: 0
+                    LCKR: bits 15:0
+              - write:
+                  - LCKK: 1
+                    LCKR: bits 15:0
+              - read:
+                  - LCKR: bits 31:0
+              - read:
+                  - LCKK: 1
+                    note: optional step, but confirms lock is active
+            fields:
+              - name: RESERVED
+                msb: 31
+                lsb: 15
+                width: 15
+                access: ro
+                settings: []
+              - name: LCKK
+                msb: 16
+                lsb: 16
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration lock key not active
+                    "1": >-
+                      Port configuration lock key active. The GPIOx_LCKR register is locked until the next MCU reset or
+                      peripheral reset.
+              - name: LCK15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+              - name: LCK0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: rw
+                settings:
+                  - "0": Port configuration not locked
+                    "1": Port configuration locked
+        - AFRL:
+            reference:
+              section: 7.4.9
+            offset: 0x20
+            fields:
+              - name: AFSEL7
+                msb: 31
+                lsb: 28
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL6
+                msb: 27
+                lsb: 24
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL5
+                msb: 23
+                lsb: 20
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL4
+                msb: 19
+                lsb: 16
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL3
+                msb: 15
+                lsb: 12
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL2
+                msb: 11
+                lsb: 8
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL1
+                msb: 7
+                lsb: 4
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL0
+                msb: 3
+                lsb: 0
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+        - AFRH:
+            reference:
+              section: 7.4.10
+            offset: 0x24
+            fields:
+              - name: AFSEL15
+                msb: 31
+                lsb: 28
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL14
+                msb: 27
+                lsb: 24
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL13
+                msb: 23
+                lsb: 20
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL12
+                msb: 19
+                lsb: 16
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL11
+                msb: 15
+                lsb: 12
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL10
+                msb: 11
+                lsb: 8
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL9
+                msb: 7
+                lsb: 4
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+              - name: AFSEL8
+                msb: 3
+                lsb: 0
+                width: 4
+                access: rw
+                settings:
+                  - "0000": AF0
+                    "0001": AF1
+                    "0010": AF2
+                    "0011": AF3
+                    "0100": AF4
+                    "0101": AF5
+                    "0110": AF6
+                    "0111": AF7
+                    "1000": AF8
+                    "1001": AF9
+                    "1010": AF10
+                    "1011": AF11
+                    "1100": AF12
+                    "1101": AF13
+                    "1110": AF14
+                    "1111": AF15
+        - BRR:
+            reference:
+              section: 7.4.11
+            offset: 0x28
+            fields:
+              - name: RESERVED
+                msb: 31
+                lsb: 16
+                width: 16
+                access: ro
+                settings: []
+              - name: BR15
+                msb: 15
+                lsb: 15
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR14
+                msb: 14
+                lsb: 14
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR13
+                msb: 13
+                lsb: 13
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR12
+                msb: 12
+                lsb: 12
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR11
+                msb: 11
+                lsb: 11
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR10
+                msb: 10
+                lsb: 10
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR9
+                msb: 9
+                lsb: 9
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR8
+                msb: 8
+                lsb: 8
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR7
+                msb: 7
+                lsb: 7
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR6
+                msb: 6
+                lsb: 6
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR5
+                msb: 5
+                lsb: 5
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR4
+                msb: 4
+                lsb: 4
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR3
+                msb: 3
+                lsb: 3
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR2
+                msb: 2
+                lsb: 2
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR1
+                msb: 1
+                lsb: 1
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit
+              - name: BR0
+                msb: 0
+                lsb: 0
+                width: 1
+                access: wo
+                settings:
+                  - "0": No action on the corresponding ODx bit
+                    "1": Reset the corresponding ODx bit

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -86,6 +86,10 @@ memory:
       start: 0x20003000
       end: 0x20009FFF
       verified: false
+      note: >-
+        Inferred gap: stm32u031 SRAM ends at 0x20002FFF and the next documented region starts
+        at 0x2000A000. This reserved entry fills the intervening address space but has not yet
+        been confirmed against the reference manual (RM0503). Mark verified: true once checked.
     - name: SRAM
       sub-families: [stm32u073, stm32u083]
       start: 0x20000000
@@ -275,6 +279,11 @@ memory:
       start: 0x40010080
       end: 0x400101FF
       base: 0x40010000
+      note: >-
+        The SYSCFG_ITLINEx registers occupy a sub-region of the SYSCFG address space starting
+        at 0x40010080. The peripheral's base address is 0x40010000 (the start of the overall
+        SYSCFG block), so register offsets from the reference manual must be computed from that
+        base, not from the sub-region start address.
     - name: COMP
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010200

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1390,20 +1390,34 @@ peripherals:
               section: 7.4.8
             offset: 0x1C
             sequence:
-              - write:
-                  - LCKK: 1
-                    LCKR: bits 15:0
-              - write:
-                  - LCKK: 0
-                    LCKR: bits 15:0
-              - write:
-                  - LCKK: 1
-                    LCKR: bits 15:0
-              - read:
-                  - LCKR: bits 31:0
-              - read:
-                  - LCKK: 1
-                    note: optional step, but confirms lock is active
+              description: >-
+                Lock sequence that must be followed exactly to freeze the port configuration.
+                Accepts one caller argument: lock-bits, a 16-bit mask (LCK0–LCK15) indicating
+                which port pins to lock. Any violation of the sequence leaves the port
+                configuration unchanged.
+              steps:
+                - op: write
+                  note: Write LCKK=1 with the desired lock-bits
+                  fields:
+                    LCKK: 1
+                    LCK: write-arg
+                - op: write
+                  note: Write LCKK=0 with the same lock-bits
+                  fields:
+                    LCKK: 0
+                    LCK: write-arg
+                - op: write
+                  note: Write LCKK=1 with the same lock-bits again
+                  fields:
+                    LCKK: 1
+                    LCK: write-arg
+                - op: read
+                  note: Read the register to complete the lock sequence (result discarded)
+                - op: read
+                  optional: true
+                  note: Optional — LCKK reads back as 1 when the lock is active
+                  expect:
+                    LCKK: 1
             fields:
               - name: RESERVED
                 msb: 31

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -85,7 +85,7 @@ memory:
       sub-families: [stm32u031]
       start: 0x20003000
       end: 0x20009FFF
-      note: This fills in a gap left by Table 3 - needs validating
+      verified: false
     - name: SRAM
       sub-families: [stm32u073, stm32u083]
       start: 0x20000000
@@ -274,7 +274,7 @@ memory:
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010080
       end: 0x400101FF
-      note: uses 0x40010000 as base address
+      base: 0x40010000
     - name: COMP
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x40010200
@@ -1182,224 +1182,208 @@ peripherals:
                 lsb: 31
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR14
                 msb: 30
                 lsb: 30
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR13
                 msb: 29
                 lsb: 29
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR12
                 msb: 28
                 lsb: 28
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR11
                 msb: 27
                 lsb: 27
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR10
                 msb: 26
                 lsb: 26
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR9
                 msb: 25
                 lsb: 25
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR8
                 msb: 24
                 lsb: 24
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR7
                 msb: 23
                 lsb: 23
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR6
                 msb: 22
                 lsb: 22
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR5
                 msb: 21
                 lsb: 21
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR4
                 msb: 20
                 lsb: 20
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR3
                 msb: 19
                 lsb: 19
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR2
                 msb: 18
                 lsb: 18
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR1
                 msb: 17
                 lsb: 17
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BR0
                 msb: 16
                 lsb: 16
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
                 settings: *bsrr-br
               - name: BS15
                 msb: 15
                 lsb: 15
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR15]
                 settings: *bsrr-bs
               - name: BS14
                 msb: 14
                 lsb: 14
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR14]
                 settings: *bsrr-bs
               - name: BS13
                 msb: 13
                 lsb: 13
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR13]
                 settings: *bsrr-bs
               - name: BS12
                 msb: 12
                 lsb: 12
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR12]
                 settings: *bsrr-bs
               - name: BS11
                 msb: 11
                 lsb: 11
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR11]
                 settings: *bsrr-bs
               - name: BS10
                 msb: 10
                 lsb: 10
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR10]
                 settings: *bsrr-bs
               - name: BS9
                 msb: 9
                 lsb: 9
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR9]
                 settings: *bsrr-bs
               - name: BS8
                 msb: 8
                 lsb: 8
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR8]
                 settings: *bsrr-bs
               - name: BS7
                 msb: 7
                 lsb: 7
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR7]
                 settings: *bsrr-bs
               - name: BS6
                 msb: 6
                 lsb: 6
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR6]
                 settings: *bsrr-bs
               - name: BS5
                 msb: 5
                 lsb: 5
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR5]
                 settings: *bsrr-bs
               - name: BS4
                 msb: 4
                 lsb: 4
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR4]
                 settings: *bsrr-bs
               - name: BS3
                 msb: 3
                 lsb: 3
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR3]
                 settings: *bsrr-bs
               - name: BS2
                 msb: 2
                 lsb: 2
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR2]
                 settings: *bsrr-bs
               - name: BS1
                 msb: 1
                 lsb: 1
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR1]
                 settings: *bsrr-bs
               - name: BS0
                 msb: 0
                 lsb: 0
                 width: 1
                 access: wo
-                note: If both BSx and BRx are set, BSx has priority.
+                priority-over: [BR0]
                 settings: *bsrr-bs
         - LCKR:
             reference:

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -75,9 +75,18 @@ memory:
       start: 0x20000000
       end: 0x3FFFFFFF
     - name: SRAM
-      sub-families: [stm32u031, stm32u073, stm32u083]
+      sub-families: [stm32u031]
       start: 0x20000000
       end: 0x20002FFF
+    - name: reserved
+      sub-families: [stm32u031]
+      start: 0x20003000
+      end: 0x20009FFF
+      note: This fills in a gap left by Table 3 - needs validating
+    - name: SRAM
+      sub-families: [stm32u073, stm32u083]
+      start: 0x20000000
+      end: 0x20009FFF
     - name: reserved
       sub-families: [stm32u031, stm32u073, stm32u083]
       start: 0x2000A000
@@ -465,9 +474,9 @@ memory:
       end: 0xE00FFFFF
 peripherals:
   - gpio:
-    reference:
-      sections: [2.2, 7.4, 7.4.12]
-      tables: [4, 41]
+      reference:
+        sections: [2.2, 7.4, 7.4.12]
+        tables: [4, 41]
     registers:
       - MODER:
         reference:

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -1,4 +1,5 @@
 ---
+spec-version: "1.0"
 vendor: STMicroelectronics
 family:
   name: stm32u0

--- a/docs/specs/stm32/stm32u0.yml
+++ b/docs/specs/stm32/stm32u0.yml
@@ -22,7 +22,7 @@ memory:
       sub-families: [stm32u031]
       start: 0x00000000
       end: 0x0001FFFF
-    - name: Main flash memory,  System memory or SRAM. Depends on boot configuration
+    - name: Main flash memory, System memory or SRAM. Depends on boot configuration
       sub-families: [stm32u073, stm32u083]
       start: 0x00000000
       end: 0x0003FFFF

--- a/lint.sh
+++ b/lint.sh
@@ -38,6 +38,11 @@ while IFS= read -r -d '' spec; do
     check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/schema.json" "${spec}"
 done < <(find "${REPO_ROOT}/docs/specs" -mindepth 2 -maxdepth 2 -name '*.yml' -print0)
 
+echo "=== model spec validation ==="
+while IFS= read -r -d '' spec; do
+    check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/schema-model.json" "${spec}"
+done < <(find "${REPO_ROOT}/docs/specs" -mindepth 3 -maxdepth 3 -name '*.yml' -path '*/models/*' -print0)
+
 echo "=== shellcheck ==="
 find "${REPO_ROOT}" -name '*.sh' -print0 | xargs -0 shellcheck
 

--- a/lint.sh
+++ b/lint.sh
@@ -35,8 +35,8 @@ yamllint -c "${REPO_ROOT}/.yamllint.yml" "${REPO_ROOT}/.github/workflows"
 
 echo "=== spec validation ==="
 while IFS= read -r -d '' spec; do
-    check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/stm32/schema.json" "${spec}"
-done < <(find "${REPO_ROOT}/docs/specs/stm32" -name '*.yml' ! -name 'schema.*' -print0)
+    check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/schema.json" "${spec}"
+done < <(find "${REPO_ROOT}/docs/specs" -mindepth 2 -maxdepth 2 -name '*.yml' -print0)
 
 echo "=== shellcheck ==="
 find "${REPO_ROOT}" -name '*.sh' -print0 | xargs -0 shellcheck

--- a/lint.sh
+++ b/lint.sh
@@ -43,6 +43,11 @@ while IFS= read -r -d '' spec; do
     check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/schema-model.json" "${spec}"
 done < <(find "${REPO_ROOT}/docs/specs" -mindepth 3 -maxdepth 3 -name '*.yml' -path '*/models/*' -print0)
 
+echo "=== arch spec validation ==="
+while IFS= read -r -d '' spec; do
+    check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/schema-arch.json" "${spec}"
+done < <(find "${REPO_ROOT}/docs/specs/common/arch" -name '*.yml' -print0)
+
 echo "=== shellcheck ==="
 find "${REPO_ROOT}" -name '*.sh' -print0 | xargs -0 shellcheck
 

--- a/lint.sh
+++ b/lint.sh
@@ -33,6 +33,11 @@ find "${REPO_ROOT}" \
 echo "=== yamllint ==="
 yamllint -c "${REPO_ROOT}/.yamllint.yml" "${REPO_ROOT}/.github/workflows"
 
+echo "=== spec validation ==="
+while IFS= read -r -d '' spec; do
+    check-jsonschema --schemafile "${REPO_ROOT}/docs/specs/stm32/schema.json" "${spec}"
+done < <(find "${REPO_ROOT}/docs/specs/stm32" -name '*.yml' ! -name 'schema.*' -print0)
+
 echo "=== shellcheck ==="
 find "${REPO_ROOT}" -name '*.sh' -print0 | xargs -0 shellcheck
 


### PR DESCRIPTION
Partial spec to incrementally build on

<!--
PR title MUST follow Conventional Commits format:

  <type>(<scope>): <short summary>

  type  : feat | fix | docs | test | ci | build | refactor | chore
  scope : optional — e.g. core | gpio | stm32u0 | pic | ci | vcpkg
  summary: present tense, lowercase, no trailing period

Examples:
  feat(gpio): add STM32U073 partial specialisation
  fix(core): correct mask calculation for Width=1 BitField at Offset=31
  docs(plan): add step-16 additional peripherals
  ci: add nRF5 cross-compile job

The PR title becomes the squash-merge commit message and is read by
release-please to determine version bumps and CHANGELOG entries.
-->
