### PR TITLE
fix: corrected stm32u083kcu model

### DIFF
--- a/docs/specs/stm32/models/stm32u083kcu.yml
+++ b/docs/specs/stm32/models/stm32u083kcu.yml
@@ -99,9 +99,9 @@ alternate-functions:
         port: A
         bit: 3
       functions:
-        AF0: TIM2_CH4
+        AF1: TIM2_CH4
         AF7: USART2_RX
-        AF8: LPUART1_TX
+        AF8: LPUART1_RX
         AF11: LCD_SEG2
         AF14: TIM15_CH2
         AF15: EVENTOUT
@@ -128,7 +128,7 @@ alternate-functions:
         AF2: TIM2_ETR
         AF5: SPI1_SCK
         AF7: USART3_TX
-        AF8: USART3_RX
+        AF8: LPUART3_RX
         AF11: LCD_SEG44
         AF14: LPTIM2_ETR
         AF15: EVENTOUT
@@ -148,7 +148,7 @@ alternate-functions:
         AF8: LPUART1_CTS
         AF9: TSC_G5_IO1
         AF11: LCD_SEG3
-        AF14: TIM15_CH1
+        AF14: TIM16_CH1
         AF15: EVENTOUT
     - pin: "PA7"
       number: 13


### PR DESCRIPTION
### AF Corrections vs. Worked Example (sourced from PDF §4.3)

Independant review found these notable differences from the validated UFQFPN32 spec:

| Pin | Field   | Worked Example | PDF Table 13 (used) |
| --- | ------- | -------------- | ------------------- |
| PA3 | AF slot | AF0            | **AF1**             |
| PA3 | AF8     | LPUART1\_TX    | **LPUART1\_RX**     |
| PA5 | AF8     | USART3\_RX     | **LPUART3\_RX**     |
| PA6 | AF14    | TIM15\_CH1     | **TIM16\_CH1**      |

<!--
PR title MUST follow Conventional Commits format:

  <type>(<scope>): <short summary>

  type  : feat | fix | docs | test | ci | build | refactor | chore
  scope : optional — e.g. core | gpio | stm32u0 | pic | ci | vcpkg
  summary: present tense, lowercase, no trailing period

Examples:
  feat(gpio): add STM32U073 partial specialisation
  fix(core): correct mask calculation for Width=1 BitField at Offset=31
  docs(plan): add step-16 additional peripherals
  ci: add nRF5 cross-compile job

The PR title becomes the squash-merge commit message and is read by
release-please to determine version bumps and CHANGELOG entries.
-->
